### PR TITLE
Index querying bookings by office and an optional date

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -234,10 +234,26 @@ const bookingsTable = new aws.dynamodb.Table('bookings-table', {
       name: 'user',
       type: 'S',
     },
+    {
+      name: 'office',
+      type: 'S',
+    },
+    {
+      name: 'date',
+      type: 'S',
+    },
   ],
   hashKey: 'user',
   rangeKey: 'id',
   billingMode: 'PAY_PER_REQUEST',
+  globalSecondaryIndexes: [
+    {
+      name: 'office-date-bookings',
+      hashKey: 'office',
+      rangeKey: 'date',
+      projectionType: 'ALL',
+    },
+  ],
   pointInTimeRecovery: {
     enabled: false,
   },

--- a/server/bookings/queryBookings.ts
+++ b/server/bookings/queryBookings.ts
@@ -1,28 +1,38 @@
 import { Config } from '../app-config';
 import { mapBookings } from './model';
-import { getUserBookings, getAllBookings, BookingsModel } from '../db/bookings';
+import {
+  getUserBookings,
+  getAllBookings,
+  BookingsModel,
+  queryBookings as queryBookingsDb,
+} from '../db/bookings';
 import { User } from '../users/model';
 import { Forbidden } from '../errors';
 
-export type BookingsQuery = { email?: string; office?: string };
+export type BookingsQuery = { email?: string; office?: string; date?: string };
 
 export const queryBookings = async (config: Config, currentUser: User, query: BookingsQuery) => {
-  const isEditingSelf = query.email && query.email === currentUser.email;
+  const isQueryingSelf = query.email && query.email === currentUser.email;
   const isOfficeAdmin =
     query.office !== undefined &&
     currentUser.permissions.officesCanManageBookingsFor.includes(query.office);
   const isAuthorised =
-    isEditingSelf || isOfficeAdmin || currentUser.permissions.canManageAllBookings;
+    isQueryingSelf || isOfficeAdmin || currentUser.permissions.canManageAllBookings;
   if (!isAuthorised) {
     throw new Forbidden();
   }
 
   const filterBookings = (booking: BookingsModel) =>
-    !query.office || booking.office === query.office;
+    (!query.office || booking.office === query.office) &&
+    (!query.date || booking.date === query.date) &&
+    (!query.email || booking.user === query.email);
 
   if (query.email) {
     const userBookings = await getUserBookings(config, query.email);
     return mapBookings(userBookings.filter(filterBookings));
+  } else if (query.office !== undefined) {
+    const officeBookings = await queryBookingsDb(config, { office: query.office });
+    return mapBookings(officeBookings.filter(filterBookings));
   } else {
     const allBookings = await getAllBookings(config);
     return mapBookings(allBookings.filter(filterBookings));

--- a/server/scripts/create-dynamo-tables.ts
+++ b/server/scripts/create-dynamo-tables.ts
@@ -1,0 +1,44 @@
+import DynamoDB from 'aws-sdk/clients/dynamodb';
+import { DataMapper } from '@aws/dynamodb-data-mapper';
+import { OfficeBookingModel } from '../db/officeBookings';
+import { UserBookingsModel } from '../db/userBookings';
+import { BookingsModel } from '../db/bookings';
+import { UserModel } from '../db/users';
+
+export const createLocalTables = async (
+  options: { deleteTablesFirst?: boolean },
+  config?: DynamoDB.ClientConfiguration
+) => {
+  const dynamo = new DynamoDB(config);
+  const mapper = new DataMapper({ client: dynamo });
+  if (options.deleteTablesFirst) {
+    await mapper.ensureTableNotExists(OfficeBookingModel);
+    await mapper.ensureTableNotExists(UserBookingsModel);
+    await mapper.ensureTableNotExists(BookingsModel);
+    await mapper.ensureTableNotExists(UserModel);
+  }
+  await mapper.ensureTableExists(OfficeBookingModel, {
+    readCapacityUnits: 1,
+    writeCapacityUnits: 1,
+  });
+  await mapper.ensureTableExists(UserBookingsModel, {
+    readCapacityUnits: 1,
+    writeCapacityUnits: 1,
+  });
+  await mapper.ensureTableExists(BookingsModel, {
+    readCapacityUnits: 1,
+    writeCapacityUnits: 1,
+    indexOptions: {
+      'office-date-bookings': {
+        type: 'global',
+        projection: 'all',
+        readCapacityUnits: 1,
+        writeCapacityUnits: 1,
+      },
+    },
+  });
+  await mapper.ensureTableExists(UserModel, {
+    readCapacityUnits: 1,
+    writeCapacityUnits: 1,
+  });
+};

--- a/server/scripts/init-dynamo-local.ts
+++ b/server/scripts/init-dynamo-local.ts
@@ -25,6 +25,14 @@ async function createTable() {
   await mapper.ensureTableExists(BookingsModel, {
     readCapacityUnits: 1,
     writeCapacityUnits: 1,
+    indexOptions: {
+      'office-date-bookings': {
+        type: 'global',
+        projection: 'all',
+        readCapacityUnits: 1,
+        writeCapacityUnits: 1,
+      },
+    },
   });
   await mapper.ensureTableExists(UserModel, {
     readCapacityUnits: 1,

--- a/server/scripts/init-dynamo-local.ts
+++ b/server/scripts/init-dynamo-local.ts
@@ -1,46 +1,12 @@
-import DynamoDB from 'aws-sdk/clients/dynamodb';
-import { DataMapper } from '@aws/dynamodb-data-mapper';
-import { OfficeBookingModel } from '../db/officeBookings';
-import { UserBookingsModel } from '../db/userBookings';
-import { BookingsModel } from '../db/bookings';
-import { UserModel } from '../db/users';
+import { createLocalTables } from './create-dynamo-tables';
 
-async function createTable() {
-  const dynamo = new DynamoDB({
+createLocalTables(
+  { deleteTablesFirst: true },
+  {
     region: 'eu-west-1',
     endpoint: 'http://localhost:8000',
-  });
-
-  const mapper = new DataMapper({
-    client: dynamo, // the SDK client used to execute operations
-  });
-  await mapper.ensureTableExists(OfficeBookingModel, {
-    readCapacityUnits: 1,
-    writeCapacityUnits: 1,
-  });
-  await mapper.ensureTableExists(UserBookingsModel, {
-    readCapacityUnits: 1,
-    writeCapacityUnits: 1,
-  });
-  await mapper.ensureTableExists(BookingsModel, {
-    readCapacityUnits: 1,
-    writeCapacityUnits: 1,
-    indexOptions: {
-      'office-date-bookings': {
-        type: 'global',
-        projection: 'all',
-        readCapacityUnits: 1,
-        writeCapacityUnits: 1,
-      },
-    },
-  });
-  await mapper.ensureTableExists(UserModel, {
-    readCapacityUnits: 1,
-    writeCapacityUnits: 1,
-  });
-}
-
-createTable().catch((e) => {
+  }
+).catch((e) => {
   console.error(e);
   process.exit(1);
 });

--- a/server/tests/test-utils.ts
+++ b/server/tests/test-utils.ts
@@ -1,13 +1,7 @@
-import { DynamoDB } from 'aws-sdk/clients/all';
-import { DataMapper } from '@aws/dynamodb-data-mapper';
-import { BookingsModel } from '../db/bookings';
-import { UserBookingsModel } from '../db/userBookings';
-import { OfficeBookingModel } from '../db/officeBookings';
 import request, { Response } from 'supertest';
 import { configureApp } from '../app';
 import { Config, OfficeQuota } from '../app-config';
-import { UserModel } from '../db/users';
-import { createLocalTables } from '../scripts/init-dynamo-local';
+import { createLocalTables } from '../scripts/create-dynamo-tables';
 
 export const normalUserEmail = 'normal.user@office-booker.test';
 export const adminUserEmail = 'office-booker-admin-test@office-booker.test';
@@ -52,7 +46,13 @@ export const server = () => {
 };
 
 export const resetDb = async () => {
-  await createLocalTables();
+  await createLocalTables(
+    { deleteTablesFirst: true },
+    {
+      region: 'eu-west-1',
+      endpoint: 'http://localhost:8000',
+    }
+  );
 };
 
 export const expectUnauthorised = (response: Response) => {

--- a/server/tests/test-utils.ts
+++ b/server/tests/test-utils.ts
@@ -6,6 +6,8 @@ import { OfficeBookingModel } from '../db/officeBookings';
 import request, { Response } from 'supertest';
 import { configureApp } from '../app';
 import { Config, OfficeQuota } from '../app-config';
+import { UserModel } from '../db/users';
+import { createLocalTables } from '../scripts/init-dynamo-local';
 
 export const normalUserEmail = 'normal.user@office-booker.test';
 export const adminUserEmail = 'office-booker-admin-test@office-booker.test';
@@ -50,29 +52,7 @@ export const server = () => {
 };
 
 export const resetDb = async () => {
-  const dynamo = new DynamoDB({
-    region: 'eu-west-1',
-    endpoint: 'http://localhost:8000',
-  });
-
-  const mapper = new DataMapper({
-    client: dynamo,
-  });
-  await mapper.ensureTableNotExists(OfficeBookingModel);
-  await mapper.ensureTableNotExists(UserBookingsModel);
-  await mapper.ensureTableNotExists(BookingsModel);
-  await mapper.ensureTableExists(OfficeBookingModel, {
-    readCapacityUnits: 1,
-    writeCapacityUnits: 1,
-  });
-  await mapper.ensureTableExists(UserBookingsModel, {
-    readCapacityUnits: 1,
-    writeCapacityUnits: 1,
-  });
-  await mapper.ensureTableExists(BookingsModel, {
-    readCapacityUnits: 1,
-    writeCapacityUnits: 1,
-  });
+  await createLocalTables();
 };
 
 export const expectUnauthorised = (response: Response) => {


### PR DESCRIPTION
- Add global secondary Index by office then date for admin searches.
- Add option to query by date from the API.
- Avoid table scans for most frequent operations.
- De-duplicate local db setup.


Co-authored-by: @otaiga 