### PR TITLE
Allow booking multiple offices on same day

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Lab team of 4 developers put together this real-time booking app in just 10 
 ### System Rules
 
 - Bookings are for the whole day
-- Users can only make 1 booking per day
+- Users can only make 1 booking per office, per day
 - Default limit of 1 booking per week per user, can be adjusted by System Administrators
 - Bookings for the today can only be cancelled by Administrators
 - Users pick a single office (can be changed in help)

--- a/server/bookings/createBooking.ts
+++ b/server/bookings/createBooking.ts
@@ -49,13 +49,6 @@ export const createBooking = async (
     });
   }
 
-  // Id date as a direct string
-  const id = request.date.replace(/-/gi, '');
-  const newBooking = {
-    ...request,
-    id,
-  };
-
   const requestedOffice = config.officeQuotas.find((office) => office.name === request.office);
   if (!requestedOffice) {
     throw new HttpError({
@@ -64,6 +57,13 @@ export const createBooking = async (
       httpMessage: 'Office not found',
     });
   }
+
+  // Id date as a direct string
+  const id = requestedOffice.id + '_' + request.date.replace(/-/gi, '');
+  const newBooking = {
+    ...request,
+    id,
+  };
 
   const userEmail = request.user.toLocaleLowerCase();
   const startOfWeek = dateStartOfWeek(request.date);

--- a/server/getOffices.ts
+++ b/server/getOffices.ts
@@ -2,6 +2,14 @@ import { getOfficeBookings } from './db/officeBookings';
 import { getAvailableDates } from './availableDates';
 import { Config } from './app-config';
 
+export const getOfficeId = (officeName: string): string => {
+  const lowered = officeName.toLowerCase();
+  return lowered.replace(/[^a-z0-9]/gi, '');
+};
+
+const officeIdPattern = new RegExp('^[a-z0-9-]+$').compile();
+export const isValidOfficeId = (officeId: string): boolean => officeIdPattern.test(officeId);
+
 export const getOffices = async (config: Config) => {
   const availableDates = getAvailableDates(config);
   const officeBookings = await getOfficeBookings(

--- a/server/tests/test-utils.ts
+++ b/server/tests/test-utils.ts
@@ -8,10 +8,12 @@ export const adminUserEmail = 'office-booker-admin-test@office-booker.test';
 export const otherUser = 'other.user@office-booker.test';
 export const officeQuotas: OfficeQuota[] = [
   {
+    id: 'office-a',
     name: 'Office A',
     quota: 100,
   },
   {
+    id: 'office-b',
     name: 'Office B',
     quota: 200,
   },


### PR DESCRIPTION
Rational: we originally thought limiting to one office per day would be fine, but there may be valid reasons for booking more than 1 office on the same day.

- Add or auto-assign office ids in config.
- Prepend booking id with office id.
- This is backward compatible - old bookings ids are still able to be loaded alongside new ones.