### PR TITLE
Revert "Use standard Authorization header"

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -20,7 +20,7 @@ const buildHeaders = async () => {
 
   return {
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${jwtToken}`,
+    bearer: jwtToken,
   };
 };
 

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -31,12 +31,6 @@ export class Forbidden extends HttpError {
   }
 }
 
-export class Unauthorized extends HttpError {
-  constructor(internalMessage?: string) {
-    super({ httpMessage: 'Unauthorized', status: 401, internalMessage });
-  }
-}
-
 export type ErrorLevel = 'ERROR' | 'INFO';
 
 type ErrorResponseArgs = {

--- a/server/tests/api-anon.test.ts
+++ b/server/tests/api-anon.test.ts
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { configureServer, expectUnauthorized, getNormalUser, officeQuotas } from './test-utils';
+import { configureServer, expectUnauthorised, getNormalUser, officeQuotas } from './test-utils';
 
 const { app, resetDb } = configureServer('anon-users');
 const normalUserEmail = getNormalUser();
@@ -8,22 +8,22 @@ beforeEach(resetDb);
 
 test('get user', async () => {
   const response = await app.get(`/api/users/${normalUserEmail}`);
-  expectUnauthorized(response);
+  expectUnauthorised(response);
 });
 
 test('get list of offices', async () => {
   const response = await app.get(`/api/offices`);
-  expectUnauthorized(response);
+  expectUnauthorised(response);
 });
 
 test('get bookings', async () => {
   const response = await app.get('/api/bookings');
-  expectUnauthorized(response);
+  expectUnauthorised(response);
 });
 
 test('get bookings by user', async () => {
   const response = await app.get(`/api/bookings?user=${normalUserEmail}`);
-  expectUnauthorized(response);
+  expectUnauthorised(response);
 });
 
 test('create booking', async () => {
@@ -32,10 +32,10 @@ test('create booking', async () => {
     office: officeQuotas[0].name,
     date: format(new Date(), 'yyyy-MM-dd'),
   });
-  expectUnauthorized(response);
+  expectUnauthorised(response);
 });
 
 test('delete booking', async () => {
   const response = await app.delete(`/api/bookings/${format(new Date(), 'yyyyMMdd')}`);
-  expectUnauthorized(response);
+  expectUnauthorised(response);
 });

--- a/server/tests/test-utils.ts
+++ b/server/tests/test-utils.ts
@@ -66,10 +66,10 @@ export const configureServer = (dynamoDBTablePrefix: string, testConfig?: TestCo
   };
 };
 
-export const expectUnauthorized = (response: Response) => {
+export const expectUnauthorised = (response: Response) => {
   expect(response.status).toBe(401);
   expect(response.body).toMatchObject({
-    message: 'Unauthorized',
+    message: 'Unauthorised',
   });
   expect(Object.keys(response.body)).toEqual(['message', 'reference', 'error']);
 };


### PR DESCRIPTION
Reverts o2Labs/office-booker#14

API Gateway currently removes the `Authorization` header. Haven't yet found an explanation of how to avoid this behaviour.