### PR TITLE
Use standard auth headers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@ set -e # stop on error
 yarn audit --cwd server --groups dependencies
 yarn audit --cwd infrastructure --groups dependencies
 yarn audit --cwd alerts --groups dependencies
-yarn audit --cwd client --groups dependencies || true # Ignore lodash issue temporarily
+yarn audit --cwd client
 
 ./test.sh
 
@@ -24,5 +24,5 @@ cp package.json ../dist/alerts
 cp yarn.lock ../dist/alerts
 
 cd ..
-yarn install --production --cwd dist/server --non-interactive
-yarn install --production --cwd dist/alerts --non-interactive
+yarn install --production --cwd dist/server --non-interactive --frozen-lockfile
+yarn install --production --cwd dist/alerts --non-interactive --frozen-lockfile

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -28,7 +28,7 @@ const buildHeaders = async () => {
 
   return {
     'Content-Type': 'application/json',
-    bearer: jwtToken,
+    Authorization: `Bearer ${jwtToken}`,
   };
 };
 

--- a/infrastructure/serverlessWebStack.ts
+++ b/infrastructure/serverlessWebStack.ts
@@ -421,6 +421,7 @@ export class ServerlessWebStack extends pulumi.ComponentResource {
           forwardedValues: {
             cookies: { forward: 'all' },
             queryString: true,
+            headers: ['Authorization'],
           },
           compress: args.compress,
           minTtl: 0,

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,6 +1,6 @@
 import { Express, Response } from 'express';
 import { Config } from './app-config';
-import { errorResponse } from './errors';
+import { Unauthorized } from './errors';
 import { validate } from './cognito';
 
 export const getAuthUserEmail = (res: Response): string => {
@@ -15,35 +15,24 @@ export const configureAuth = (config: Config, app: Express): Express => {
   return app.use(async (req, res, next) => {
     try {
       if (config.authConfig.type === 'test') {
-        try {
-          const response = config.authConfig.validate(req);
-          const userEmail = response?.email;
-          if (typeof userEmail !== 'string') {
-            return errorResponse(req, res, {
-              error: Error('Email property missing on auth validate response'),
-              status: 401,
-              level: 'INFO',
-              body: { message: 'Unauthorised' },
-            });
-          }
-          res.locals.user =
-            config.caseSensitiveEmail === true ? userEmail : userEmail.toLocaleLowerCase();
-          next();
-        } catch (error) {
-          return errorResponse(req, res, { error, status: 401, body: { message: 'Unauthorised' } });
+        const response = config.authConfig.validate(req);
+        const userEmail = response?.email;
+        if (typeof userEmail !== 'string') {
+          throw new Unauthorized('Email property missing on auth validate response');
         }
+        res.locals.user =
+          config.caseSensitiveEmail === true ? userEmail : userEmail.toLocaleLowerCase();
+        next();
       } else {
         //I'm passing in the access token in header under key accessToken
-        const bearerHeader = req.headers.bearer;
+        const authHeader = req.headers.authorization;
 
         //Fail if token not present in header.
-        if (typeof bearerHeader !== 'string')
-          return errorResponse(req, res, {
-            error: Error('id Token missing from header'),
-            status: 401,
-            level: 'INFO',
-            body: { message: 'Unauthorised' },
-          });
+        if (typeof authHeader !== 'string') throw new Unauthorized('Header not set');
+        const bearerRegex = /^Bearer ([a-zA-Z0-9_\-\.]*)$/g;
+        const parsed = bearerRegex.exec(authHeader);
+        const token = parsed?.[1];
+        if (typeof token !== 'string') throw new Unauthorized('Could not parse Bearer token');
 
         const authResult = await validate(
           {
@@ -51,7 +40,7 @@ export const configureAuth = (config: Config, app: Express): Express => {
             userPoolId: config.authConfig.cognitoUserPoolId,
             tokenUse: 'id',
           },
-          bearerHeader
+          token
         );
         if (authResult.valid) {
           const userEmail = authResult.token.email as string;
@@ -59,12 +48,7 @@ export const configureAuth = (config: Config, app: Express): Express => {
             config.caseSensitiveEmail === true ? userEmail : userEmail.toLocaleLowerCase();
           next();
         } else {
-          return errorResponse(req, res, {
-            error: new Error(authResult.reason),
-            status: 401,
-            level: 'INFO',
-            body: { message: 'Unauthorised' },
-          });
+          throw new Unauthorized('Bearer token not valid');
         }
       }
     } catch (e) {

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -31,6 +31,12 @@ export class Forbidden extends HttpError {
   }
 }
 
+export class Unauthorized extends HttpError {
+  constructor(internalMessage?: string) {
+    super({ httpMessage: 'Unauthorized', status: 401, internalMessage });
+  }
+}
+
 export type ErrorLevel = 'ERROR' | 'INFO';
 
 type ErrorResponseArgs = {

--- a/server/tests/api-anon.test.ts
+++ b/server/tests/api-anon.test.ts
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { configureServer, expectUnauthorised, getNormalUser, officeQuotas } from './test-utils';
+import { configureServer, expectUnauthorized, getNormalUser, officeQuotas } from './test-utils';
 
 const { app, resetDb } = configureServer('anon-users');
 const normalUserEmail = getNormalUser();
@@ -8,22 +8,22 @@ beforeEach(resetDb);
 
 test('get user', async () => {
   const response = await app.get(`/api/users/${normalUserEmail}`);
-  expectUnauthorised(response);
+  expectUnauthorized(response);
 });
 
 test('get list of offices', async () => {
   const response = await app.get(`/api/offices`);
-  expectUnauthorised(response);
+  expectUnauthorized(response);
 });
 
 test('get bookings', async () => {
   const response = await app.get('/api/bookings');
-  expectUnauthorised(response);
+  expectUnauthorized(response);
 });
 
 test('get bookings by user', async () => {
   const response = await app.get(`/api/bookings?user=${normalUserEmail}`);
-  expectUnauthorised(response);
+  expectUnauthorized(response);
 });
 
 test('create booking', async () => {
@@ -32,10 +32,10 @@ test('create booking', async () => {
     office: officeQuotas[0].name,
     date: format(new Date(), 'yyyy-MM-dd'),
   });
-  expectUnauthorised(response);
+  expectUnauthorized(response);
 });
 
 test('delete booking', async () => {
   const response = await app.delete(`/api/bookings/${format(new Date(), 'yyyyMMdd')}`);
-  expectUnauthorised(response);
+  expectUnauthorized(response);
 });

--- a/server/tests/test-utils.ts
+++ b/server/tests/test-utils.ts
@@ -67,10 +67,10 @@ export const configureServer = (dynamoDBTablePrefix: string, testConfig?: TestCo
   };
 };
 
-export const expectUnauthorised = (response: Response) => {
+export const expectUnauthorized = (response: Response) => {
   expect(response.status).toBe(401);
   expect(response.body).toMatchObject({
-    message: 'Unauthorised',
+    message: 'Unauthorized',
   });
   expect(Object.keys(response.body)).toEqual(['message', 'reference', 'error']);
 };


### PR DESCRIPTION
Second version of #14 to fix #13 

We were missing an option to forward _all_ headers from CloudFront to API gateway.