### PR TITLE
Fix test that fails on Fridays

### DIFF
--- a/server/tests/booking.test.ts
+++ b/server/tests/booking.test.ts
@@ -72,7 +72,7 @@ describe('Testing DB logic', async () => {
   test('can create booking with parking and successfully increase booking count and parking count', async () => {
     const normalUserEmail = getNormalUser();
     const office = officeQuotas[0].name;
-    const date = format(addDays(new Date(), 1), 'yyyy-MM-dd');
+    const date = format(addDays(nextMonday, 1), 'yyyy-MM-dd');
     const createBookingBody = {
       user: normalUserEmail,
       office,
@@ -101,7 +101,7 @@ describe('Testing DB logic', async () => {
   test('can delete booking with parking and successfully decrease booking count and parking count', async () => {
     const normalUserEmail = getNormalUser();
     const office = officeQuotas[0].name;
-    const date = format(addDays(new Date(), 1), 'yyyy-MM-dd');
+    const date = format(addDays(nextMonday, 1), 'yyyy-MM-dd');
     const createBookingBody = {
       user: normalUserEmail,
       office,
@@ -135,7 +135,7 @@ describe('Testing DB logic', async () => {
   test('cannot have multiple bookings on the same day', async () => {
     const normalUserEmail = getNormalUser();
     const office = officeQuotas[0].name;
-    const date = format(addDays(new Date(), 1), 'yyyy-MM-dd');
+    const date = format(addDays(nextMonday, 1), 'yyyy-MM-dd');
     const createBookingBody = {
       user: normalUserEmail,
       office,
@@ -171,7 +171,7 @@ describe('Testing DB logic', async () => {
     for (const day of days) {
       const res = await app
         .post('/api/bookings')
-        .send({ ...createBookingBody, date: format(addDays(new Date(), day), 'yyyy-MM-dd') })
+        .send({ ...createBookingBody, date: format(addDays(nextMonday, day), 'yyyy-MM-dd') })
         .set('bearer', normalUserEmail);
       expect(res.ok).toBe(true);
     }
@@ -180,7 +180,7 @@ describe('Testing DB logic', async () => {
       .post('/api/bookings')
       .send({
         ...createBookingBody,
-        date: format(addDays(new Date(), config.defaultWeeklyQuota + 1), 'yyyy-MM-dd'),
+        date: format(addDays(nextMonday, config.defaultWeeklyQuota + 1), 'yyyy-MM-dd'),
       })
       .set('bearer', normalUserEmail);
 


### PR DESCRIPTION
When counting forwards three days, on Friday, Saturday or Sunday, it'll roll-over to a new week and therefore get a new quota, therefore not failing.

Use 'next Monday' as the standard starting point for all tests.