### PR TITLE
42 admin users

### DIFF
--- a/client/src/components/App/Admin/Bookings.styles.ts
+++ b/client/src/components/App/Admin/Bookings.styles.ts
@@ -63,6 +63,7 @@ export default styled.div`
 
     > .table {
       padding: 0 1.6rem 3rem;
+      overflow: scroll;
     }
 
     .table-header {

--- a/client/src/components/App/Admin/Bookings.tsx
+++ b/client/src/components/App/Admin/Bookings.tsx
@@ -159,7 +159,7 @@ const Bookings: React.FC<RouteComponentProps> = () => {
           <>
             <h3>Bookings</h3>
 
-            <Button
+            <OurButton
               startIcon={<AddCircleIcon />}
               type="submit"
               color="secondary"
@@ -168,7 +168,7 @@ const Bookings: React.FC<RouteComponentProps> = () => {
               size="small"
             >
               New Booking
-            </Button>
+            </OurButton>
 
             {selectedOffice && (
               <Paper square className="table-container">

--- a/client/src/components/App/Admin/CreateBooking.tsx
+++ b/client/src/components/App/Admin/CreateBooking.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect, useCallback, useReducer } from 'react';
+import React, { useContext, useState, useEffect, useCallback } from 'react';
 import { RouteComponentProps } from '@reach/router';
 import format from 'date-fns/format';
 import addDays from 'date-fns/addDays';
@@ -10,9 +10,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import TextField from '@material-ui/core/TextField';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
-import Snackbar from '@material-ui/core/Snackbar';
 import Paper from '@material-ui/core/Paper';
-import Alert, { AlertProps } from '@material-ui/lab/Alert';
 
 import { AppContext } from '../../AppProvider';
 
@@ -27,52 +25,6 @@ import { validateEmail } from '../../../lib/emailValidation';
 
 import CreateBookingStyles from './CreateBooking.styles';
 
-// Reducers
-type Alert = {
-  message: string;
-  severity: AlertProps['severity'];
-  visible: boolean;
-};
-
-type AlertSet = {
-  type: 'set';
-  payload: {
-    message: Alert['message'];
-    severity: Alert['severity'];
-  };
-};
-
-type AlertHide = {
-  type: 'hide';
-};
-
-type AlertActions = AlertSet | AlertHide;
-
-const initialAlert: Alert = {
-  message: '',
-  severity: 'info',
-  visible: false,
-};
-
-const alertReducer = (state: Alert, action: AlertActions) => {
-  switch (action.type) {
-    case 'set':
-      return {
-        ...state,
-        ...action.payload,
-        visible: true,
-      };
-    case 'hide':
-      return {
-        ...state,
-        visible: false,
-      };
-    default:
-      return state;
-  }
-};
-
-// Component
 const AdminCreateBooking: React.FC<RouteComponentProps> = () => {
   // Global state
   const { state, dispatch } = useContext(AppContext);
@@ -86,9 +38,6 @@ const AdminCreateBooking: React.FC<RouteComponentProps> = () => {
   const [bookingDate, setBookingDate] = useState(addDays(new Date(), +1));
   const [email, setEmail] = useState('');
   const [parking, setParking] = useState(false);
-
-  // Reducers
-  const [alert, alertDispatch] = useReducer(alertReducer, initialAlert);
 
   // Helpers
   const findOffice = useCallback(
@@ -142,51 +91,51 @@ const AdminCreateBooking: React.FC<RouteComponentProps> = () => {
 
     // Validation
     if (email === '') {
-      return alertDispatch({
-        type: 'set',
+      return dispatch({
+        type: 'SET_ALERT',
         payload: {
-          severity: 'error',
           message: 'Email address required',
+          color: 'error',
         },
       });
     }
 
     if (!config || !validateEmail(config.emailRegex, email)) {
-      return alertDispatch({
-        type: 'set',
+      return dispatch({
+        type: 'SET_ALERT',
         payload: {
-          severity: 'error',
           message: 'Valid email address required',
+          color: 'error',
         },
       });
     }
 
     if (!office || !officeSlot) {
-      return alertDispatch({
-        type: 'set',
+      return dispatch({
+        type: 'SET_ALERT',
         payload: {
-          severity: 'error',
           message: 'Office required',
+          color: 'error',
         },
       });
     }
 
     if (officeSlot.booked + 1 > office.quota) {
-      return alertDispatch({
-        type: 'set',
+      return dispatch({
+        type: 'SET_ALERT',
         payload: {
-          severity: 'error',
           message: 'No office spaces available',
+          color: 'error',
         },
       });
     }
 
     if (office.parkingQuota > 0 && parking && officeSlot.bookedParking + 1 > office.parkingQuota) {
-      return alertDispatch({
-        type: 'set',
+      return dispatch({
+        type: 'SET_ALERT',
         payload: {
-          severity: 'error',
-          message: 'No parking spaces available',
+          message: 'No office parking spaces available',
+          color: 'error',
         },
       });
     }
@@ -214,11 +163,11 @@ const AdminCreateBooking: React.FC<RouteComponentProps> = () => {
         setEmail('');
 
         // Show success alert
-        alertDispatch({
-          type: 'set',
+        dispatch({
+          type: 'SET_ALERT',
           payload: {
-            severity: 'success',
             message: `Booking created for ${email}!`,
+            color: 'success',
           },
         });
       })
@@ -351,16 +300,6 @@ const AdminCreateBooking: React.FC<RouteComponentProps> = () => {
                 </OurButton>
               </form>
             </Paper>
-
-            <Snackbar open={alert.visible} onClose={() => alertDispatch({ type: 'hide' })}>
-              <Alert
-                variant="filled"
-                severity={alert.severity}
-                onClose={() => alertDispatch({ type: 'hide' })}
-              >
-                {alert.message}
-              </Alert>
-            </Snackbar>
           </>
         )}
       </CreateBookingStyles>

--- a/client/src/components/App/Admin/User.styles.ts
+++ b/client/src/components/App/Admin/User.styles.ts
@@ -1,158 +1,101 @@
 import styled from 'styled-components';
 
 export default styled.div`
-  ${(props) => props.theme.breakpoints.up('xs')} {
-    margin: 0 2rem 2.4rem;
-    .MuiPaper-root {
-      padding: 2rem 2rem 2.4rem;
-    }
+  ${(props) => props.theme.breakpoints.only('xs')} {
+    padding: 0 2rem 2rem;
   }
 
   ${(props) => props.theme.breakpoints.up('sm')} {
-    margin: 0 3rem 4rem;
-    .MuiPaper-root {
-      padding: 3rem 3rem 4rem;
-    }
+    padding: 0 3rem 3rem;
   }
 
-  margin: 0 3rem;
+  > h3 {
+    margin: 0 0 1.4rem;
 
-  p,
-  label {
-    color: ${(props) => props.theme.palette.secondary.main};
-    font-size: 1.6rem;
-    font-weight: 400;
+    color: ${(props) => props.theme.palette.primary.main};
+    font-size: 1.8rem;
+    font-weight: 500;
+  }
 
-    margin: 0;
+  > .form-container {
+    padding: 2rem 3rem 3rem;
 
-    > a {
+    > h4 {
+      margin: 0 0 1.6rem;
+
+      color: ${(props) => props.theme.palette.secondary.main};
+      font-size: 1.6rem;
+      font-weight: 700;
+    }
+
+    > h5 {
+      margin: 0 0 2.4rem;
+
       color: ${(props) => props.theme.palette.primary.main};
-    }
-  }
-
-  .breadcrumb-text {
-    margin: 0;
-  }
-
-  .breadcrumb-text.previous {
-    color: #000000de;
-  }
-
-  .filters {
-    margin-bottom: 2rem;
-    display: flex;
-
-    ${(props) => props.theme.breakpoints.up('xs')} {
-      flex-direction: column;
-
-      .search-user {
-        .MuiFormControl-root {
-          width: 100%;
-        }
-      }
-
-      .filter-roles {
-        margin-top: 3rem;
-      }
+      font-size: 1.6rem;
+      font-weight: 500;
     }
 
-    ${(props) => props.theme.breakpoints.up('sm')} {
-      flex-direction: row;
-      justify-content: space-between;
+    > form {
+      > .field {
+        margin-bottom: 2.4rem;
 
-      .search-user {
-        margin-right: 4rem;
+        .input {
+          ${(props) => props.theme.breakpoints.only('xs')} {
+            width: 100%;
+          }
 
-        .MuiFormControl-root {
-          min-width: 30rem;
-        }
-      }
-
-      .filter-roles {
-        margin: 0rem;
-      }
-    }
-
-    .search-user {
-      display: flex;
-      align-items: center;
-      form {
-        width: 100%;
-      }
-    }
-
-    .filter-roles {
-      .MuiSelect-select {
-        min-width: 12rem;
-      }
-    }
-  }
-
-  .edit-user {
-    form {
-      .user-email-tt {
-        font-size: 2.5rem;
-        margin: 2rem 0;
-      }
-
-      h4 {
-        margin-bottom: 2rem;
-        color: #000000de;
-      }
-
-      .MuiFormControl-root {
-        min-width: 25rem;
-
-        margin-right: 1rem;
-      }
-
-      input {
-        font-size: 2.5rem;
-      }
-
-      .buttons {
-        margin-top: 2rem;
-
-        button {
-          margin-right: 1rem;
-        }
-      }
-
-      .role-container {
-        display: flex;
-        flex-direction: column;
-
-        margin-bottom: 2rem;
-
-        .MuiFormControl-root {
-          margin-bottom: 1.5rem;
-        }
-
-        .chips-select {
-          .MuiSelect-select {
-            overflow: scroll;
+          ${(props) => props.theme.breakpoints.up('sm')} {
+            min-width: 25rem;
           }
         }
       }
     }
   }
 
-  .docs {
-    margin-top: 1em;
+  > .help {
+    margin-top: 3rem;
 
-    > p,
-    ul > li {
-      color: ${(props) => props.theme.palette.secondary.main};
+    > h3 {
+      margin: 0 0 1.4rem;
+
+      color: ${(props) => props.theme.palette.primary.main};
+      font-size: 1.8rem;
+      font-weight: 400;
     }
-  }
 
-  .listing-container {
-    overflow: scroll;
-  }
+    > h4 {
+      margin: 0 0 1.4rem;
 
-  .load-more-container {
-    display: flex;
-    justify-content: center;
-    margin: 1rem 0;
+      color: ${(props) => props.theme.palette.primary.main};
+      font-size: 1.4rem;
+      font-weight: 700;
+    }
+
+    p {
+      margin: 0 0 2rem;
+
+      color: ${(props) => props.theme.palette.secondary.main};
+      font-size: 1.4rem;
+      font-weight: 400;
+
+      > a {
+        color: ${(props) => props.theme.palette.primary.main};
+      }
+    }
+
+    > ul {
+      margin: 0;
+
+      &:not(:last-child) {
+        margin-bottom: 2.2rem;
+      }
+
+      > li {
+        color: ${(props) => props.theme.palette.secondary.main};
+        font-size: 1.4rem;
+        font-weight: 400;
+      }
+    }
   }
 `;

--- a/client/src/components/App/Admin/Users.styles.ts
+++ b/client/src/components/App/Admin/Users.styles.ts
@@ -27,20 +27,50 @@ export default styled.div`
         flex-direction: column;
       }
 
-      ${(props) => props.theme.breakpoints.up('sm')} {
+      ${(props) => props.theme.breakpoints.only('sm')} {
+        align-items: flex-start;
+      }
+
+      ${(props) => props.theme.breakpoints.up('md')} {
         align-items: center;
       }
 
       padding: 3rem 3rem 2rem;
 
-      > .filter-roles {
-        flex: 0 0 auto;
-      }
-
-      > .filter-quota {
+      > .filter-roles-and-quota {
         flex: 1 1 auto;
 
-        padding: 1.6rem 0 0 3rem;
+        display: flex;
+
+        ${(props) => props.theme.breakpoints.down('sm')} {
+          flex-direction: column;
+        }
+
+        ${(props) => props.theme.breakpoints.up('md')} {
+          align-items: center;
+
+          padding-right: 2rem;
+        }
+
+        > .filter-role {
+          flex: 0 0 auto;
+        }
+
+        > .filter-quota {
+          flex: 1 1 auto;
+
+          ${(props) => props.theme.breakpoints.down('sm')} {
+            padding: 1rem 0 0 0;
+
+            > label {
+              margin-left: 0;
+            }
+          }
+
+          ${(props) => props.theme.breakpoints.up('md')} {
+            padding: 1.6rem 0 0 2rem;
+          }
+        }
       }
 
       > .search-user {

--- a/client/src/components/App/Admin/Users.styles.ts
+++ b/client/src/components/App/Admin/Users.styles.ts
@@ -18,6 +18,8 @@ export default styled.div`
   }
 
   > .table-container {
+    margin-top: 2rem;
+
     > .filters {
       display: flex;
 
@@ -27,13 +29,18 @@ export default styled.div`
 
       ${(props) => props.theme.breakpoints.up('sm')} {
         align-items: center;
-        justify-content: space-between;
       }
 
       padding: 3rem 3rem 2rem;
 
       > .filter-roles {
         flex: 0 0 auto;
+      }
+
+      > .filter-quota {
+        flex: 1 1 auto;
+
+        padding: 1.6rem 0 0 3rem;
       }
 
       > .search-user {
@@ -49,26 +56,41 @@ export default styled.div`
       padding: 0 1.6rem 3rem;
       overflow: scroll;
     }
-  }
 
-  > .load-more-container {
-    padding: 0 3rem 3rem;
+    .table-header {
+      font-weight: 700;
+    }
 
-    text-align: center;
-  }
+    > .load-more-container {
+      padding: 0 3rem 3rem;
 
-  > .unregistered-user {
-    padding: 0 3rem 3rem;
+      text-align: center;
+    }
 
-    > p {
-      color: ${(props) => props.theme.palette.secondary.main};
-      font-size: 1.6rem;
-      font-weight: 400;
+    > .unregistered-user {
+      display: flex;
+      align-items: center;
 
-      margin: 0;
+      padding: 0 3rem 3rem;
 
-      > a {
-        color: ${(props) => props.theme.palette.primary.main};
+      > p {
+        flex: 0 1 auto;
+
+        padding-right: 2rem;
+
+        color: ${(props) => props.theme.palette.secondary.main};
+        font-size: 1.6rem;
+        font-weight: 400;
+
+        margin: 0;
+
+        > span {
+          color: ${(props) => props.theme.palette.primary.main};
+        }
+      }
+
+      > button {
+        flex: 0 0 auto;
       }
     }
   }

--- a/client/src/components/App/Admin/Users.styles.ts
+++ b/client/src/components/App/Admin/Users.styles.ts
@@ -27,50 +27,15 @@ export default styled.div`
         flex-direction: column;
       }
 
-      ${(props) => props.theme.breakpoints.only('sm')} {
-        align-items: flex-start;
-      }
-
-      ${(props) => props.theme.breakpoints.up('md')} {
-        align-items: center;
+      ${(props) => props.theme.breakpoints.up('sm')} {
+        align-items: flex-end;
+        justify-content: space-between;
       }
 
       padding: 3rem 3rem 2rem;
 
-      > .filter-roles-and-quota {
-        flex: 1 1 auto;
-
-        display: flex;
-
-        ${(props) => props.theme.breakpoints.down('sm')} {
-          flex-direction: column;
-        }
-
-        ${(props) => props.theme.breakpoints.up('md')} {
-          align-items: center;
-
-          padding-right: 2rem;
-        }
-
-        > .filter-role {
-          flex: 0 0 auto;
-        }
-
-        > .filter-quota {
-          flex: 1 1 auto;
-
-          ${(props) => props.theme.breakpoints.down('sm')} {
-            padding: 1rem 0 0 0;
-
-            > label {
-              margin-left: 0;
-            }
-          }
-
-          ${(props) => props.theme.breakpoints.up('md')} {
-            padding: 1.6rem 0 0 2rem;
-          }
-        }
+      > .filter-role {
+        flex: 0 0 auto;
       }
 
       > .search-user {
@@ -80,6 +45,13 @@ export default styled.div`
           padding-top: 2rem;
         }
       }
+    }
+
+    > p.note {
+      margin: 0 3rem 2rem;
+
+      font-size: 1.4rem;
+      font-style: italic;
     }
 
     > .table {
@@ -98,29 +70,39 @@ export default styled.div`
     }
 
     > .unregistered-user {
-      display: flex;
-      align-items: center;
-
       padding: 0 3rem 3rem;
 
       > p {
-        flex: 0 1 auto;
+        margin: 2rem 0 0;
 
-        padding-right: 2rem;
-
-        color: ${(props) => props.theme.palette.secondary.main};
-        font-size: 1.6rem;
+        font-size: 1.4rem;
         font-weight: 400;
-
-        margin: 0;
-
-        > span {
-          color: ${(props) => props.theme.palette.primary.main};
-        }
+        font-style: italic;
       }
 
-      > button {
-        flex: 0 0 auto;
+      > .link {
+        display: flex;
+        align-items: center;
+
+        > p {
+          flex: 0 1 auto;
+
+          padding-right: 2rem;
+
+          color: ${(props) => props.theme.palette.secondary.main};
+          font-size: 1.6rem;
+          font-weight: 400;
+
+          margin: 0;
+
+          > span {
+            color: ${(props) => props.theme.palette.primary.main};
+          }
+        }
+
+        > button {
+          flex: 0 0 auto;
+        }
       }
     }
   }

--- a/client/src/components/App/Admin/Users.tsx
+++ b/client/src/components/App/Admin/Users.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useEffect } from 'react';
-import { RouteComponentProps, Link } from '@reach/router';
+import { RouteComponentProps, navigate } from '@reach/router';
 import TableContainer from '@material-ui/core/TableContainer';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
@@ -11,10 +11,14 @@ import InputLabel from '@material-ui/core/InputLabel';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import TextField from '@material-ui/core/TextField';
+import Checkbox from '@material-ui/core/Checkbox';
 import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import CreateIcon from '@material-ui/icons/Create';
 import SearchIcon from '@material-ui/icons/Search';
+import AddCircleIcon from '@material-ui/icons/AddCircle';
+import IconButton from '@material-ui/core/IconButton';
 
 import { AppContext } from '../../AppProvider';
 import Loading from '../../Assets/LoadingSpinner';
@@ -31,21 +35,25 @@ import UsersStyles from './Users.styles';
 
 // Types
 type UserFilter = {
-  name: 'System Admin' | 'Office Admin' | 'custom' | 'all';
+  role: 'all' | 'System Admin' | 'Office Admin';
+  customQuota: boolean;
   email?: string;
 };
 
 // Helpers
 const userFilterToQuery = (filter: UserFilter): UserQuery => {
   const query: UserQuery = { emailPrefix: filter.email };
-  if (filter.name === 'Office Admin') {
+
+  if (filter.role === 'Office Admin') {
     query.role = 'Office Admin';
-  } else if (filter.name === 'System Admin') {
+  } else if (filter.role === 'System Admin') {
     query.role = 'System Admin';
   }
-  if (filter.name === 'custom') {
+
+  if (filter.customQuota) {
     query.quota = 'custom';
   }
+
   return query;
 };
 
@@ -58,12 +66,16 @@ const Users: React.FC<RouteComponentProps> = () => {
   // Local state
   const [loading, setLoading] = useState(true);
   const [queryResult, setQueryResult] = useState<User[] | undefined>(undefined);
-  const [paginationToken, setPaginationToken] = useState<string | undefined>(undefined);
-  const [selectedFilter, setSelectedFilter] = useState<UserFilter>({ name: 'System Admin' });
+  const [paginationToken, setPaginationToken] = useState<string | undefined>();
+  const [selectedFilter, setSelectedFilter] = useState<UserFilter>({
+    role: 'all',
+    customQuota: false,
+  });
   const [email, setEmail] = useState<string>('');
 
   // Effects
   useEffect(() => {
+    // Retrieve results
     queryUsers(userFilterToQuery(selectedFilter))
       .then((result) => {
         setQueryResult(result.users);
@@ -87,20 +99,41 @@ const Users: React.FC<RouteComponentProps> = () => {
     }
   }, [queryResult]);
 
+  useEffect(() => {
+    // Search after typing has stopped
+    const sanitisedEmail = email.trim().toLowerCase();
+
+    const searchEmailTimer = setTimeout(() => {
+      setSelectedFilter((filter) => ({
+        ...filter,
+        email: sanitisedEmail,
+      }));
+    }, 1000);
+
+    // Cleanup
+    return () => clearTimeout(searchEmailTimer);
+  }, [email]);
+
   // Handlers
-  const handleSelectedRoleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    const val = event.target.value;
-    if (val === 'System Admin' || val === 'Office Admin' || val === 'custom' || val === 'all') {
-      setSelectedFilter((filter) => ({ ...filter, name: val }));
+  const handleRoleFilter = (e: React.ChangeEvent<{ value: unknown }>) => {
+    const role = e.target.value as string;
+
+    if (role === 'all' || role === 'System Admin' || role === 'Office Admin') {
+      setSelectedFilter((filter) => ({ ...filter, role }));
     }
   };
 
   const loadMore = () => {
-    if (paginationToken && selectedFilter.name === 'all') {
+    if (paginationToken && selectedFilter.role === 'all') {
+      // Clear the current token
       setPaginationToken(undefined);
+
+      // Retrieve data after pagination token
       queryUsers({}, paginationToken)
         .then((result) => {
+          // Merge new results with existing
           setQueryResult((previousUsers) => [...(previousUsers ?? []), ...result.users]);
+
           setPaginationToken(result.paginationToken);
         })
         .catch((error) =>
@@ -120,51 +153,64 @@ const Users: React.FC<RouteComponentProps> = () => {
   return (
     <AdminLayout currentRoute="users">
       <UsersStyles>
-        {' '}
         {loading ? (
           <Loading />
         ) : (
           <>
             <h3>Users</h3>
 
+            <OurButton
+              startIcon={<AddCircleIcon />}
+              type="submit"
+              color="secondary"
+              onClick={() => {}}
+              variant="contained"
+              size="small"
+            >
+              New user
+            </OurButton>
+
             <Paper square className="table-container">
               <section className="filters">
                 <div className="filter-roles">
-                  <FormControl variant="outlined">
-                    <InputLabel style={{ backgroundColor: '#ffffff' }}>Select Filter</InputLabel>
-                    <Select value={selectedFilter.name} onChange={handleSelectedRoleChange}>
-                      <MenuItem value={'System Admin'}>System Admins</MenuItem>
-                      <MenuItem value={'Office Admin'}>Office Admins</MenuItem>
-                      <MenuItem value={'custom'}>Users with Custom Quota</MenuItem>
-                      <MenuItem value={'all'}>All Registered Users</MenuItem>
+                  <FormControl>
+                    <InputLabel>User Role</InputLabel>
+                    <Select value={selectedFilter.role} onChange={handleRoleFilter}>
+                      <MenuItem value="all">All Registered Users</MenuItem>
+                      <MenuItem value="System Admin">System Admins</MenuItem>
+                      <MenuItem value="Office Admin">Office Admins</MenuItem>
                     </Select>
                   </FormControl>
                 </div>
 
+                <div className="filter-quota">
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={selectedFilter.customQuota}
+                        onChange={(_, checked) =>
+                          setSelectedFilter((filter) => ({ ...filter, customQuota: checked }))
+                        }
+                      />
+                    }
+                    label="Custom quota?"
+                    labelPlacement="start"
+                  />
+                </div>
+
                 <div className="search-user">
-                  <form
-                    onSubmit={(e) => {
-                      e.preventDefault();
-                      const sanitisedEmail = email.trim().toLowerCase();
-                      setSelectedFilter((filter) => ({
-                        ...filter,
-                        email: sanitisedEmail === '' ? undefined : sanitisedEmail,
-                      }));
+                  <TextField
+                    placeholder="Start of email address"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    InputProps={{
+                      startAdornment: (
+                        <InputAdornment position="start">
+                          <SearchIcon />
+                        </InputAdornment>
+                      ),
                     }}
-                  >
-                    <TextField
-                      placeholder="Start of email address"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      InputProps={{
-                        startAdornment: (
-                          <InputAdornment position="start">
-                            <SearchIcon />
-                          </InputAdornment>
-                        ),
-                      }}
-                    />
-                  </form>
+                  />
                 </div>
               </section>
 
@@ -172,27 +218,30 @@ const Users: React.FC<RouteComponentProps> = () => {
                 <Table>
                   <TableHead>
                     <TableRow>
-                      <TableCell>User Email</TableCell>
-                      <TableCell>Quota</TableCell>
-                      <TableCell>Role</TableCell>
+                      <TableCell className="table-header">User Email</TableCell>
+                      <TableCell className="table-header">Quota</TableCell>
+                      <TableCell className="table-header">Role</TableCell>
+                      <TableCell className="table-header" />
                     </TableRow>
                   </TableHead>
                   <TableBody>
                     {queryResult && queryResult.length > 0 ? (
                       queryResult.map((user) => (
                         <TableRow key={user.email}>
-                          <TableCell>
-                            <Link to={`/admin/users/${user.email}`}>
-                              {user.email} <CreateIcon />
-                            </Link>
-                          </TableCell>
+                          <TableCell>{user.email}</TableCell>
                           <TableCell>{user.quota}</TableCell>
                           <TableCell>{user.role.name}</TableCell>
+                          <TableCell align="right">
+                            <IconButton onClick={() => navigate(`/admin/users/${user.email}`)}>
+                              <CreateIcon />
+                            </IconButton>
+                          </TableCell>
                         </TableRow>
                       ))
                     ) : (
                       <TableRow>
                         <TableCell>No users found</TableCell>
+                        <TableCell />
                         <TableCell />
                         <TableCell />
                       </TableRow>
@@ -203,25 +252,31 @@ const Users: React.FC<RouteComponentProps> = () => {
 
               {paginationToken && (
                 <section className="load-more-container">
-                  <OurButton onClick={loadMore} variant="contained">
+                  <OurButton onClick={loadMore} color="primary" variant="contained">
                     Load More
                   </OurButton>
                 </section>
               )}
 
-              {selectedFilter.name === 'all' &&
+              {selectedFilter.role === 'all' &&
                 selectedFilter.email !== undefined &&
                 validateEmail(state.config?.emailRegex, selectedFilter.email) &&
                 queryResult?.length === 0 && (
                   <section className="unregistered-user">
                     <p>
-                      User not yet registered, edit{' '}
-                      <Link to={`/admin/users/${selectedFilter.email}`}>
-                        {selectedFilter.email}
-                        <CreateIcon />
-                      </Link>{' '}
-                      anyway.
+                      User <span>{selectedFilter.email}</span> not yet registered
                     </p>
+
+                    <OurButton
+                      startIcon={<AddCircleIcon />}
+                      type="submit"
+                      variant="contained"
+                      color="primary"
+                      onClick={() => navigate(`/admin/users/${selectedFilter.email}`)}
+                      size="small"
+                    >
+                      Add user
+                    </OurButton>
                   </section>
                 )}
             </Paper>

--- a/client/src/components/App/Admin/Users.tsx
+++ b/client/src/components/App/Admin/Users.tsx
@@ -172,30 +172,32 @@ const Users: React.FC<RouteComponentProps> = () => {
 
             <Paper square className="table-container">
               <section className="filters">
-                <div className="filter-roles">
-                  <FormControl>
-                    <InputLabel>User Role</InputLabel>
-                    <Select value={selectedFilter.role} onChange={handleRoleFilter}>
-                      <MenuItem value="all">All Registered Users</MenuItem>
-                      <MenuItem value="System Admin">System Admins</MenuItem>
-                      <MenuItem value="Office Admin">Office Admins</MenuItem>
-                    </Select>
-                  </FormControl>
-                </div>
+                <div className="filter-roles-and-quota">
+                  <div className="filter-role">
+                    <FormControl>
+                      <InputLabel>User Role</InputLabel>
+                      <Select value={selectedFilter.role} onChange={handleRoleFilter}>
+                        <MenuItem value="all">All Registered Users</MenuItem>
+                        <MenuItem value="System Admin">System Admins</MenuItem>
+                        <MenuItem value="Office Admin">Office Admins</MenuItem>
+                      </Select>
+                    </FormControl>
+                  </div>
 
-                <div className="filter-quota">
-                  <FormControlLabel
-                    control={
-                      <Checkbox
-                        checked={selectedFilter.customQuota}
-                        onChange={(_, checked) =>
-                          setSelectedFilter((filter) => ({ ...filter, customQuota: checked }))
-                        }
-                      />
-                    }
-                    label="Custom quota?"
-                    labelPlacement="start"
-                  />
+                  <div className="filter-quota">
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={selectedFilter.customQuota}
+                          onChange={(_, checked) =>
+                            setSelectedFilter((filter) => ({ ...filter, customQuota: checked }))
+                          }
+                        />
+                      }
+                      label="Custom quota?"
+                      labelPlacement="start"
+                    />
+                  </div>
                 </div>
 
                 <div className="search-user">

--- a/client/src/components/App/Admin/Users.tsx
+++ b/client/src/components/App/Admin/Users.tsx
@@ -8,6 +8,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TableBody from '@material-ui/core/TableBody';
 import Paper from '@material-ui/core/Paper';
 import InputLabel from '@material-ui/core/InputLabel';
+import Button from '@material-ui/core/Button';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import TextField from '@material-ui/core/TextField';
@@ -15,6 +16,10 @@ import Checkbox from '@material-ui/core/Checkbox';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import InputAdornment from '@material-ui/core/InputAdornment';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
 import CreateIcon from '@material-ui/icons/Create';
 import SearchIcon from '@material-ui/icons/Search';
 import AddCircleIcon from '@material-ui/icons/AddCircle';
@@ -73,6 +78,10 @@ const Users: React.FC<RouteComponentProps> = () => {
   });
   const [email, setEmail] = useState<string>('');
 
+  const [showAddUser, setShowAddUser] = useState(false);
+  const [addUserEmail, setAddUserEmail] = useState('');
+  const [addUserError, setAddUserError] = useState(false);
+
   // Effects
   useEffect(() => {
     // Retrieve results
@@ -123,7 +132,7 @@ const Users: React.FC<RouteComponentProps> = () => {
     }
   };
 
-  const loadMore = () => {
+  const handleLoadMore = () => {
     if (paginationToken && selectedFilter.role === 'all') {
       // Clear the current token
       setPaginationToken(undefined);
@@ -145,6 +154,16 @@ const Users: React.FC<RouteComponentProps> = () => {
     }
   };
 
+  const handleAdduser = () => {
+    if (validateEmail(state.config?.emailRegex, addUserEmail)) {
+      setAddUserError(false);
+
+      navigate(`/admin/users/${addUserEmail}`);
+    } else {
+      setAddUserError(true);
+    }
+  };
+
   // Render
   if (!user) {
     return null;
@@ -163,7 +182,7 @@ const Users: React.FC<RouteComponentProps> = () => {
               startIcon={<AddCircleIcon />}
               type="submit"
               color="secondary"
-              onClick={() => {}}
+              onClick={() => setShowAddUser(true)}
               variant="contained"
               size="small"
             >
@@ -254,7 +273,7 @@ const Users: React.FC<RouteComponentProps> = () => {
 
               {paginationToken && (
                 <section className="load-more-container">
-                  <OurButton onClick={loadMore} color="primary" variant="contained">
+                  <OurButton onClick={handleLoadMore} color="primary" variant="contained">
                     Load More
                   </OurButton>
                 </section>
@@ -282,6 +301,38 @@ const Users: React.FC<RouteComponentProps> = () => {
                   </section>
                 )}
             </Paper>
+
+            <Dialog open={showAddUser} onClose={() => setShowAddUser(false)}>
+              <DialogContent>
+                <DialogContentText>
+                  Please enter the email address for the user you wish to create
+                </DialogContentText>
+
+                <TextField
+                  autoFocus
+                  label="Email Address"
+                  type="email"
+                  value={addUserEmail}
+                  onChange={(e) => setAddUserEmail(e.target.value)}
+                  error={addUserError}
+                  helperText={addUserError && `Invalid email address`}
+                  fullWidth
+                />
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={() => setShowAddUser(false)} color="primary" autoFocus>
+                  Cancel
+                </Button>
+                <Button
+                  startIcon={<AddCircleIcon />}
+                  variant="contained"
+                  onClick={() => handleAdduser()}
+                  color="secondary"
+                >
+                  New user
+                </Button>
+              </DialogActions>
+            </Dialog>
           </>
         )}
       </UsersStyles>


### PR DESCRIPTION
Updates to styling and behaviour of the `/admin/users` route:
- Styling updates to table
- Email search now auto-submitting after typing has stopped
- Changed wording around "active" users and included supporting test
- New button to create a new use

Also updated the `/admin/users/:user` route:
- Styling updates
- Using "autocomplete" component for office selection
- Forced validation on quota (between 0-7)
- Extra validation

Please note this also includes refactoring the previously updated "Create Booking" page (`/admin/booking`) to use the globally dispatched alerts.
