### PR TITLE
63 parking reducer

### DIFF
--- a/client/src/components/App/Admin/CreateBooking.tsx
+++ b/client/src/components/App/Admin/CreateBooking.tsx
@@ -156,6 +156,17 @@ const AdminCreateBooking: React.FC<RouteComponentProps> = () => {
 
     createBooking(email, formattedDate, selectedOffice.name, parking)
       .then(() => {
+        // Increase office quota
+        // This assumes the date and selected office haven't changed
+        setOfficeSlot(
+          (slot) =>
+            slot && {
+              ...slot,
+              booked: slot.booked += 1,
+              bookedParking: parking ? (slot.bookedParking += 1) : slot.bookedParking,
+            }
+        );
+
         // Clear form
         setEmail('');
         setParking(false);

--- a/client/src/components/App/Admin/User.tsx
+++ b/client/src/components/App/Admin/User.tsx
@@ -85,7 +85,7 @@ const UserAdmin: React.FC<RouteComponentProps<{ email: string }>> = (props) => {
           });
         });
     }
-  }, [user, selectedUser]);
+  }, [user, selectedUser, dispatch]);
 
   useEffect(() => {
     if (offices) {

--- a/client/src/components/App/Help.tsx
+++ b/client/src/components/App/Help.tsx
@@ -11,7 +11,6 @@ import { getUserCached, getOffices } from '../../lib/api';
 import { formatError } from '../../lib/app';
 
 import HelpStyles from './Help.styles';
-import { Office } from '../../types/api';
 
 const Help: React.FC<RouteComponentProps> = () => {
   // Global state

--- a/client/src/components/App/Help.tsx
+++ b/client/src/components/App/Help.tsx
@@ -115,6 +115,10 @@ const Help: React.FC<RouteComponentProps> = () => {
   };
 
   // Render
+  if (!state.config) {
+    return null;
+  }
+
   return (
     <Layout>
       <HelpStyles>
@@ -126,7 +130,7 @@ const Help: React.FC<RouteComponentProps> = () => {
 
         <h3>General Information</h3>
 
-        <p>Bookings can only be made {state.config?.advancedBookingDays} days in advance.</p>
+        <p>Bookings can only be made {state.config.advancedBookingDays} days in advance.</p>
 
         {user && currentOffice && (
           <div className="change-office">

--- a/client/src/components/App/Home.tsx
+++ b/client/src/components/App/Home.tsx
@@ -44,7 +44,7 @@ const Home: React.FC<RouteComponentProps> = () => {
           },
         });
       });
-  }, []);
+  }, [dispatch]);
 
   useEffect(() => {
     if (allOffices) {
@@ -72,7 +72,7 @@ const Home: React.FC<RouteComponentProps> = () => {
         setLoading(false);
       }
     }
-  }, [allOffices, office]);
+  }, [allOffices, office, dispatch]);
 
   useEffect(() => {
     if (currentOffice && user) {
@@ -92,7 +92,7 @@ const Home: React.FC<RouteComponentProps> = () => {
           });
         });
     }
-  }, [currentOffice]);
+  }, [currentOffice, user, dispatch]);
 
   useEffect(() => {
     if (userBookings) {

--- a/client/src/components/App/Home.tsx
+++ b/client/src/components/App/Home.tsx
@@ -9,8 +9,9 @@ import WhichOffice from './Home/WhichOffice';
 import NextBooking from './Home/NextBooking';
 import MakeBooking from './Home/MakeBooking';
 
-import { getOffices } from '../../lib/api';
+import { getOffices, getBookings } from '../../lib/api';
 import { formatError } from '../../lib/app';
+import { Office, Booking } from '../../types/api';
 
 import HomeStyles from './Home.styles';
 
@@ -18,40 +19,90 @@ import HomeStyles from './Home.styles';
 const Home: React.FC<RouteComponentProps> = () => {
   // Global state
   const { state, dispatch } = useContext(AppContext);
-  const { office } = state;
+  const { user, office } = state;
 
   // Local state
   const [loading, setLoading] = useState(true);
+  const [currentOffice, setCurrentOffice] = useState<Office | undefined>();
+  const [userBookings, setUserBookings] = useState<Booking[] | undefined>();
 
   // Effects
   useEffect(() => {
-    // Restore selected office from local storage
-    const localOffice = localStorage.getItem('office');
+    // Retrieve current office
+    const selectedOffice = office || localStorage.getItem('office') || undefined;
 
-    if (!office && localOffice) {
+    if (selectedOffice) {
       getOffices()
         .then((data) => {
-          // Validate local storage and set global state
-          const findOffice = data.find((o) => o.name === localOffice);
+          // Validate selected office
+          const findOffice = data.find((o) => o.name === selectedOffice);
 
-          dispatch({
-            type: 'SET_OFFICE',
-            payload: findOffice && findOffice.name,
-          });
+          if (findOffice) {
+            setCurrentOffice(findOffice);
+
+            // Update global state if coming from local storage
+            if (!office) {
+              dispatch({
+                type: 'SET_OFFICE',
+                payload: findOffice.name,
+              });
+            }
+          } else {
+            setLoading(false);
+          }
         })
-        .catch((err) =>
+        .catch((err) => {
+          // Handle errors
+          setLoading(false);
+
           dispatch({
             type: 'SET_ALERT',
             payload: {
               message: formatError(err),
               color: 'error',
             },
-          })
-        );
+          });
+        });
     } else {
       setLoading(false);
     }
   }, [dispatch, office]);
+
+  useEffect(() => {
+    if (currentOffice && user) {
+      // Get users bookings
+      getBookings({ user: user.email })
+        .then((data) => setUserBookings(data))
+        .catch((err) => {
+          // Handle errors
+          setLoading(false);
+
+          dispatch({
+            type: 'SET_ALERT',
+            payload: {
+              message: formatError(err),
+              color: 'error',
+            },
+          });
+        });
+    }
+  }, [currentOffice]);
+
+  useEffect(() => {
+    if (userBookings) {
+      // Wait until we've finished finding bookings
+      setLoading(false);
+    }
+  }, [userBookings]);
+
+  // Handlers
+  const handleAddBooking = (newBooking: Booking) =>
+    setUserBookings((bookings) => (bookings ? [...bookings, newBooking] : [newBooking]));
+
+  const handleCancelBooking = (bookingId: Booking['id']) =>
+    setUserBookings((bookings) =>
+      bookings ? bookings.filter((booking) => booking.id !== bookingId) : []
+    );
 
   // Render
   return (
@@ -59,11 +110,18 @@ const Home: React.FC<RouteComponentProps> = () => {
       <HomeStyles>
         {loading ? (
           <Loading />
-        ) : office ? (
-          <>
-            <NextBooking />
-            <MakeBooking />
-          </>
+        ) : currentOffice ? (
+          userBookings && (
+            <>
+              <NextBooking bookings={userBookings} />
+              <MakeBooking
+                office={currentOffice}
+                bookings={userBookings}
+                addBooking={handleAddBooking}
+                cancelBooking={handleCancelBooking}
+              />
+            </>
+          )
         ) : (
           <WhichOffice />
         )}

--- a/client/src/components/App/Home.tsx
+++ b/client/src/components/App/Home.tsx
@@ -101,6 +101,13 @@ const Home: React.FC<RouteComponentProps> = () => {
     }
   }, [userBookings]);
 
+  useEffect(() => {
+    if (!office) {
+      // Clear everything when the global office is cleared
+      setCurrentOffice(undefined);
+    }
+  }, [office]);
+
   // Handlers
   const handleAddBooking = (newBooking: Booking) =>
     setUserBookings((bookings) => (bookings ? [...bookings, newBooking] : [newBooking]));

--- a/client/src/components/App/Home/NextBooking.tsx
+++ b/client/src/components/App/Home/NextBooking.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { navigate } from '@reach/router';
 import parse from 'date-fns/parse';
 import format from 'date-fns/format';
@@ -23,12 +23,10 @@ const NextBooking: React.FC<Props> = (props) => {
 
   // Effects
   useEffect(() => {
-    const { bookings } = props;
-
-    if (bookings.length > 0) {
+    if (props.bookings.length > 0) {
       // Find a booking for today
       setTodaysBooking(
-        bookings.find((b) => isToday(parse(b.date, 'y-MM-dd', new Date(), DATE_FNS_OPTIONS)))
+        props.bookings.find((b) => isToday(parse(b.date, 'y-MM-dd', new Date(), DATE_FNS_OPTIONS)))
       );
     }
   }, [props.bookings]);

--- a/client/src/components/App/Home/NextBooking.tsx
+++ b/client/src/components/App/Home/NextBooking.tsx
@@ -5,34 +5,36 @@ import format from 'date-fns/format';
 import isToday from 'date-fns/isToday';
 import Link from '@material-ui/core/Link';
 
-import { AppContext } from '../../AppProvider';
-
 import { DATE_FNS_OPTIONS } from '../../../constants/dates';
 import { Booking } from '../../../types/api';
 
 import { OurButton } from '../../../styles/MaterialComponents';
 import NextBookingStyles from './NextBooking.styles';
 
-const NextBooking: React.FC = () => {
-  // Global state
-  const { state } = useContext(AppContext);
-  const { bookings } = state;
+// Types
+type Props = {
+  bookings: Booking[];
+};
 
+// Component
+const NextBooking: React.FC<Props> = (props) => {
   // Local state
-  const [booking, setBooking] = useState<Booking | undefined>();
+  const [todaysBooking, setTodaysBooking] = useState<Booking | undefined>();
 
   // Effects
   useEffect(() => {
-    if (bookings) {
+    const { bookings } = props;
+
+    if (bookings.length > 0) {
       // Find a booking for today
-      setBooking(
+      setTodaysBooking(
         bookings.find((b) => isToday(parse(b.date, 'y-MM-dd', new Date(), DATE_FNS_OPTIONS)))
       );
     }
-  }, [bookings]);
+  }, [props.bookings]);
 
   // Render
-  if (!booking) {
+  if (!todaysBooking) {
     return null;
   }
 
@@ -42,11 +44,11 @@ const NextBooking: React.FC = () => {
 
       <h3>
         {format(
-          parse(booking.date, 'y-MM-dd', new Date(), DATE_FNS_OPTIONS),
+          parse(todaysBooking.date, 'y-MM-dd', new Date(), DATE_FNS_OPTIONS),
           'do LLL',
           DATE_FNS_OPTIONS
         )}{' '}
-        <span>@</span> {booking.office}
+        <span>@</span> {todaysBooking.office}
       </h3>
 
       <OurButton
@@ -54,7 +56,7 @@ const NextBooking: React.FC = () => {
         variant="contained"
         color="primary"
         onClick={() => {
-          navigate(`./booking/${booking?.id}`);
+          navigate(`./booking/${todaysBooking?.id}`);
         }}
       >
         View pass

--- a/client/src/components/App/Home/WhichOffice.tsx
+++ b/client/src/components/App/Home/WhichOffice.tsx
@@ -6,9 +6,15 @@ import { Office } from '../../../types/api';
 import { OurButton } from '../../../styles/MaterialComponents';
 import WhichOfficeStyles from './WhichOffice.styles';
 
-const WhichOffice: React.FC = () => {
+// Types
+type Props = {
+  offices: Office[];
+};
+
+// Component
+const WhichOffice: React.FC<Props> = (props) => {
   // Global state
-  const { state, dispatch } = useContext(AppContext);
+  const { dispatch } = useContext(AppContext);
 
   // Handlers
   const selectOffice = (office: Office) => {
@@ -21,8 +27,8 @@ const WhichOffice: React.FC = () => {
 
     // Store in global state
     dispatch({
-      type: 'SET_CURRENT_OFFICE',
-      payload: office,
+      type: 'SET_OFFICE',
+      payload: office.name,
     });
   };
 
@@ -32,7 +38,7 @@ const WhichOffice: React.FC = () => {
       <h2>Select your office</h2>
 
       <div className="buttons">
-        {state.offices.map((o) => (
+        {props.offices.map((o) => (
           <OurButton
             key={o.name}
             variant="outlined"

--- a/client/src/components/App/PageNotFound.styles.ts
+++ b/client/src/components/App/PageNotFound.styles.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export default styled.div`
+  ${(props) => props.theme.breakpoints.up('xs')} {
+    padding: 2rem 2rem 2.4rem;
+  }
+
+  ${(props) => props.theme.breakpoints.up('sm')} {
+    padding: 3rem 3rem 4rem;
+  }
+
+  > h2 {
+    margin: 0 0 1.4rem;
+
+    color: ${(props) => props.theme.palette.primary.main};
+    font-size: 2.4rem;
+    font-weight: 400;
+  }
+
+  > p {
+    color: ${(props) => props.theme.palette.secondary.main};
+    font-size: 1.6rem;
+    font-weight: 400;
+    margin: 0 0 2rem;
+  }
+`;

--- a/client/src/components/App/PageNotFound.tsx
+++ b/client/src/components/App/PageNotFound.tsx
@@ -2,49 +2,30 @@ import React, { useState, useEffect } from 'react';
 import { RouteComponentProps, navigate, Redirect } from '@reach/router';
 
 import Layout from '../Layout/Layout';
-import styled from 'styled-components';
 import { OurButton } from '../../styles/MaterialComponents';
 
-const PageNotFoundStyle = styled.div`
-  ${(props) => props.theme.breakpoints.up('xs')} {
-    padding: 2rem 2rem 2.4rem;
-  }
+import PageNotFoundStyles from './PageNotFound.styles';
 
-  ${(props) => props.theme.breakpoints.up('sm')} {
-    padding: 3rem 3rem 4rem;
-  }
-
-  > h2 {
-    margin: 0 0 1.4rem;
-
-    color: ${(props) => props.theme.palette.primary.main};
-    font-size: 2.4rem;
-    font-weight: 400;
-  }
-
-  > p {
-    color: ${(props) => props.theme.palette.secondary.main};
-    font-size: 1.6rem;
-    font-weight: 400;
-    margin: 0 0 2rem;
-  }
-`;
-
-const PageNotFound = (props: RouteComponentProps) => {
+const PageNotFound: React.FC<RouteComponentProps> = () => {
+  // Local state
   const [activateRedirect, setActivateRedirect] = useState(false);
 
+  // Effects
   useEffect(() => {
     setTimeout(() => {
       setActivateRedirect(true);
     }, 5000);
   }, []);
 
+  // Render
   return (
     <Layout>
-      <PageNotFoundStyle>
+      <PageNotFoundStyles>
         <h2>Page Not Found</h2>
         <p>We&apos;ll redirect you to home in 5 seconds</p>
-        {activateRedirect ? <Redirect to="/" noThrow /> : null}{' '}
+
+        {activateRedirect && <Redirect to="/" noThrow />}
+
         <OurButton
           type="submit"
           variant="contained"
@@ -55,7 +36,7 @@ const PageNotFound = (props: RouteComponentProps) => {
         >
           Redirect Now
         </OurButton>
-      </PageNotFoundStyle>
+      </PageNotFoundStyles>
     </Layout>
   );
 };

--- a/client/src/components/App/UpcomingBookings.tsx
+++ b/client/src/components/App/UpcomingBookings.tsx
@@ -29,10 +29,8 @@ const UpcomingBookings: React.FC<RouteComponentProps> = () => {
 
   // Effects
   useEffect(() => {
-    const { user } = state;
-
-    if (user) {
-      getBookings({ user: user.email })
+    if (state.user) {
+      getBookings({ user: state.user.email })
         .then((data) => {
           // Split for previous and upcoming
           const today = format(startOfDay(new Date()), 'yyyy-MM-dd');
@@ -53,7 +51,7 @@ const UpcomingBookings: React.FC<RouteComponentProps> = () => {
           });
         });
     }
-  }, [dispatch]);
+  }, [state.user, dispatch]);
 
   useEffect(() => {
     // Find booking

--- a/client/src/components/App/UpcomingBookings.tsx
+++ b/client/src/components/App/UpcomingBookings.tsx
@@ -4,57 +4,63 @@ import Paper from '@material-ui/core/Paper';
 import format from 'date-fns/format';
 import parse from 'date-fns/parse';
 import startOfDay from 'date-fns/startOfDay';
+
 import { AppContext } from '../AppProvider';
 
+import Layout from '../Layout/Layout';
 import LoadingSpinner from '../Assets/LoadingSpinner';
 import { OurButton } from '../../styles/MaterialComponents';
-import Layout from '../Layout/Layout';
 
 import { getBookings } from '../../lib/api';
 import { formatError } from '../../lib/app';
 import { DATE_FNS_OPTIONS } from '../../constants/dates';
+import { Booking } from '../../types/api';
 
 import UpcomingBookingsStyles from './UpcomingBookings.styles';
 
 const UpcomingBookings: React.FC<RouteComponentProps> = () => {
   // Global state
   const { state, dispatch } = useContext(AppContext);
-  const { user, bookings } = state;
 
   // Local state
   const [loading, setLoading] = useState(true);
+  const [upcomingBookings, setUpcomingBookings] = useState<Booking[] | undefined>();
+  const [previousBookings, setPreviousBookings] = useState<Booking[] | undefined>();
 
+  // Effects
   useEffect(() => {
-    if (user && !bookings) {
-      // If coming direct, retrieve from DB
+    const { user } = state;
+
+    if (user) {
       getBookings({ user: user.email })
-        .then((data) =>
-          // Store in global state
+        .then((data) => {
+          // Split for previous and upcoming
+          const today = format(startOfDay(new Date()), 'yyyy-MM-dd');
+
+          setUpcomingBookings(data.filter((b) => b.date >= today));
+          setPreviousBookings(data.filter((b) => b.date < today));
+        })
+        .catch((err) => {
+          // Handle errors
+          setLoading(false);
+
           dispatch({
-            type: 'SET_BOOKINGS',
-            payload: data,
-          })
-        )
-        .catch((err) =>
-          dispatch({
-            type: 'SET_ERROR',
-            payload: formatError(err),
-          })
-        );
+            type: 'SET_ALERT',
+            payload: {
+              message: formatError(err),
+              color: 'error',
+            },
+          });
+        });
     }
-  }, [dispatch, user, bookings]);
+  }, [dispatch]);
 
   useEffect(() => {
     // Find booking
-    if (bookings) {
+    if (upcomingBookings && previousBookings) {
       setLoading(false);
     }
-  }, [bookings]);
-
-  const today = format(startOfDay(new Date()), 'yyyy-MM-dd');
-
-  const upcomingBookings = bookings?.filter((b) => b.date >= today);
-  const previousBookings = bookings?.filter((b) => b.date < today);
+  }, [upcomingBookings, previousBookings]);
 
   // Render
   return (
@@ -64,6 +70,7 @@ const UpcomingBookings: React.FC<RouteComponentProps> = () => {
       ) : (
         <UpcomingBookingsStyles>
           <h2>Upcoming Bookings</h2>
+
           {upcomingBookings && upcomingBookings.length > 0 ? (
             <Paper square className="bookings">
               {upcomingBookings.map((row, index) => (
@@ -118,6 +125,7 @@ const UpcomingBookings: React.FC<RouteComponentProps> = () => {
               </ul>
             </>
           )}
+
           {previousBookings && previousBookings.length > 0 && (
             <>
               <h3>Previous Bookings</h3>
@@ -138,6 +146,7 @@ const UpcomingBookings: React.FC<RouteComponentProps> = () => {
               </ul>
             </>
           )}
+
           <div className="button">
             <OurButton
               type="button"

--- a/client/src/components/AppProvider.tsx
+++ b/client/src/components/AppProvider.tsx
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import React, { createContext, useReducer } from 'react';
-import { AppStore, initialAppState } from '../context/stores';
+import { AppStore } from '../context/stores';
 import { appReducer } from '../context/reducers';
 
 // Context provider
 export const AppContext = createContext<AppStore>({
-  state: initialAppState,
+  state: {},
   dispatch: () => {},
 });
 
 export const AppProvider: React.FC = (props) => {
-  const [state, dispatch] = useReducer(appReducer, initialAppState);
+  const [state, dispatch] = useReducer(appReducer, {});
 
   return <AppContext.Provider value={{ state, dispatch }}>{props.children}</AppContext.Provider>;
 };

--- a/client/src/components/Auth/EnterCode.tsx
+++ b/client/src/components/Auth/EnterCode.tsx
@@ -43,8 +43,11 @@ const EnterCode: React.FC<Props> = (props) => {
         setLoading(false);
 
         return dispatch({
-          type: 'SET_ERROR',
-          payload: 'Invalid verification code, please try again',
+          type: 'SET_ALERT',
+          payload: {
+            message: 'Invalid verification code, please try again',
+            color: 'error',
+          },
         });
       }
 
@@ -54,8 +57,11 @@ const EnterCode: React.FC<Props> = (props) => {
         setLoading(false);
 
         return dispatch({
-          type: 'SET_ERROR',
-          payload: 'User not found',
+          type: 'SET_ALERT',
+          payload: {
+            message: 'User not found',
+            color: 'error',
+          },
         });
       }
 
@@ -69,8 +75,11 @@ const EnterCode: React.FC<Props> = (props) => {
         )
         .catch((err) =>
           dispatch({
-            type: 'SET_ERROR',
-            payload: err,
+            type: 'SET_ALERT',
+            payload: {
+              message: err,
+              color: 'error',
+            },
           })
         );
     } catch (err) {
@@ -80,24 +89,34 @@ const EnterCode: React.FC<Props> = (props) => {
       // When can no longer try again, it comes through as an object
       if (typeof err === 'string') {
         return dispatch({
-          type: 'SET_ERROR',
-          payload: err,
+          type: 'SET_ALERT',
+          payload: {
+            message: err,
+            color: 'error',
+          },
         });
       }
 
       if (err.code === 'NotAuthorizedException') {
         // Wrong code entered 3 times or expired
         dispatch({
-          type: 'SET_ERROR',
-          payload:
-            'Sending a new code. Previous code has expired or was entered incorrectly too many times.',
+          type: 'SET_ALERT',
+          payload: {
+            message:
+              'Sending a new code. Previous code has expired or was entered incorrectly too many times.',
+            color: 'error',
+          },
         });
+
         return props.onCodeExpired();
       }
 
       dispatch({
-        type: 'SET_ERROR',
-        payload: formatError(err),
+        type: 'SET_ALERT',
+        payload: {
+          message: formatError(err),
+          color: 'error',
+        },
       });
     }
   };

--- a/client/src/components/Auth/EnterEmail.tsx
+++ b/client/src/components/Auth/EnterEmail.tsx
@@ -43,16 +43,22 @@ const EnterEmail: React.FC<Props> = (props) => {
         })
         .catch((err) => {
           dispatch({
-            type: 'SET_ERROR',
-            payload: formatError(err),
+            type: 'SET_ALERT',
+            payload: {
+              message: formatError(err),
+              color: 'error',
+            },
           });
 
           setLoading(false);
         });
     } else {
       dispatch({
-        type: 'SET_ERROR',
-        payload: 'Email address not permitted',
+        type: 'SET_ALERT',
+        payload: {
+          message: 'Email address not permitted',
+          color: 'error',
+        },
       });
 
       setLoading(false);

--- a/client/src/components/Auth/RequireLogin.tsx
+++ b/client/src/components/Auth/RequireLogin.tsx
@@ -48,15 +48,21 @@ const RequireLogin: React.FC<RouteComponentProps> = (props) => {
             )
             .catch((err) =>
               dispatch({
-                type: 'SET_ERROR',
-                payload: formatError(err),
+                type: 'SET_ALERT',
+                payload: {
+                  message: formatError(err),
+                  color: 'error',
+                },
               })
             );
         })
         .catch((err) =>
           dispatch({
-            type: 'SET_ERROR',
-            payload: formatError(err),
+            type: 'SET_ALERT',
+            payload: {
+              message: formatError(err),
+              color: 'error',
+            },
           })
         );
     } else {

--- a/client/src/components/Layout/Footer.tsx
+++ b/client/src/components/Layout/Footer.tsx
@@ -24,6 +24,7 @@ const Footer: React.FC = () => {
         .then((username) => {
           // Retrieve DB user
           if (username) {
+            // Retrieve cached user
             getUserCached(username)
               .then((data) =>
                 dispatch({
@@ -33,16 +34,22 @@ const Footer: React.FC = () => {
               )
               .catch((err) =>
                 dispatch({
-                  type: 'SET_ERROR',
-                  payload: formatError(err),
+                  type: 'SET_ALERT',
+                  payload: {
+                    message: formatError(err),
+                    color: 'error',
+                  },
                 })
               );
           }
         })
         .catch((err) =>
           dispatch({
-            type: 'SET_ERROR',
-            payload: formatError(err),
+            type: 'SET_ALERT',
+            payload: {
+              message: formatError(err),
+              color: 'error',
+            },
           })
         );
     }
@@ -59,8 +66,11 @@ const Footer: React.FC = () => {
       })
       .catch((err) =>
         dispatch({
-          type: 'SET_ERROR',
-          payload: formatError(err),
+          type: 'SET_ALERT',
+          payload: {
+            message: formatError(err),
+            color: 'error',
+          },
         })
       );
   };

--- a/client/src/components/Structure.tsx
+++ b/client/src/components/Structure.tsx
@@ -4,7 +4,6 @@ import Snackbar from '@material-ui/core/Snackbar';
 import Alert from '@material-ui/lab/Alert';
 
 import { AppContext } from './AppProvider';
-import { AppState } from '../context/stores';
 
 import RequireLogin from './Auth/RequireLogin';
 import Layout from './Layout/Layout';
@@ -32,8 +31,9 @@ const Structure: React.FC = () => {
   const { state, dispatch } = useContext(AppContext);
 
   // Local state
-  const [currentAlert, setCurrentAlert] = useState<AppState['alert']>(undefined);
+  const [showAlert, setShowAlert] = useState(false);
 
+  // Effects
   useEffect(() => {
     if (!state.config) {
       fetch('/api/config')
@@ -56,28 +56,26 @@ const Structure: React.FC = () => {
     }
   }, [state.config, dispatch]);
 
-  // Effects
   useEffect(() => {
-    // Set local error
     if (state.alert) {
-      setCurrentAlert(state.alert);
+      setShowAlert(true);
     }
   }, [state.alert]);
 
-  useEffect(() => {
-    // Clear Global error
-    if (!currentAlert) {
-      // Wait for transition to finish before clearing
-      setCurrentAlert(undefined);
-    }
-  }, [currentAlert]);
-
   // Handlers
-  const handleCloseError = () =>
-    dispatch({
-      type: 'SET_ALERT',
-      payload: undefined,
-    });
+  const handleCloseAlert = () => {
+    setShowAlert(false);
+
+    // Clear global state after animation
+    setTimeout(
+      () =>
+        dispatch({
+          type: 'SET_ALERT',
+          payload: undefined,
+        }),
+      TRANSITION_DURATION
+    );
+  };
 
   // Render
   return (
@@ -109,16 +107,16 @@ const Structure: React.FC = () => {
           </Router>
 
           <Snackbar
-            open={!!currentAlert}
-            onClose={handleCloseError}
+            open={showAlert}
+            onClose={() => handleCloseAlert()}
             transitionDuration={TRANSITION_DURATION}
           >
             <Alert
               variant="filled"
-              severity={currentAlert?.color || 'info'}
-              onClose={handleCloseError}
+              severity={state.alert?.color || 'info'}
+              onClose={() => handleCloseAlert()}
             >
-              {currentAlert?.message || ''}
+              {state.alert?.message || ''}
             </Alert>
           </Snackbar>
         </>

--- a/client/src/context/reducers.ts
+++ b/client/src/context/reducers.ts
@@ -1,75 +1,12 @@
-import { AppState, Config } from './stores';
-import { User, Office, Booking, OfficeSlot } from '../types/api';
-import { Color } from '@material-ui/lab/Alert';
+import { AppState, Config, Alert } from './stores';
+import { User } from '../types/api';
 
 // Types
-type OfficeSlotPayload = {
-  office: Office['name'];
-  date: string;
-};
-
 type ActionSetConfig = { type: 'SET_CONFIG'; payload: Config };
 type ActionSetUser = { type: 'SET_USER'; payload: User | undefined };
-type ActionSetOffices = { type: 'SET_OFFICES'; payload: Office[] };
-type ActionSetCurrentOffice = { type: 'SET_CURRENT_OFFICE'; payload: Office | undefined };
-type ActionSetBookings = { type: 'SET_BOOKINGS'; payload: Booking[] };
-type ActionAddBookings = { type: 'ADD_BOOKING'; payload: Booking };
-type ActionRemoveBookings = { type: 'REMOVE_BOOKING'; payload: Booking['id'] };
-type ActionIncreaseOfficeSlot = { type: 'INCREASE_OFFICE_SLOT'; payload: OfficeSlotPayload };
-type ActionDecreaseOfficeSlot = { type: 'DECREASE_OFFICE_SLOT'; payload: OfficeSlotPayload };
-type ActionSetError = { type: 'SET_ERROR'; payload: string | undefined; color?: Color };
-type ActionSetAlert = {
-  type: 'SET_ALERT';
-  payload: { message: string; color: Color } | undefined;
-};
+type ActionSetAlert = { type: 'SET_ALERT'; payload: Alert | undefined };
 
-export type AppAction =
-  | ActionSetConfig
-  | ActionSetUser
-  | ActionSetOffices
-  | ActionSetCurrentOffice
-  | ActionSetBookings
-  | ActionAddBookings
-  | ActionRemoveBookings
-  | ActionIncreaseOfficeSlot
-  | ActionDecreaseOfficeSlot
-  | ActionSetError
-  | ActionSetAlert;
-
-// Helpers
-const updateSlots = (
-  allOffices: Office[],
-  office: Office['name'],
-  date: OfficeSlot['date'],
-  action: 'increase' | 'decrease'
-) =>
-  allOffices.map((o) => {
-    if (o.name !== office) {
-      return o;
-    }
-
-    const slots = o.slots.map((s) => {
-      if (s.date !== date) {
-        return s;
-      }
-
-      // Update counter
-      return {
-        ...s,
-        booked:
-          action === 'increase'
-            ? (s.booked += 1)
-            : action === 'decrease'
-            ? (s.booked -= 1)
-            : s.booked,
-      };
-    });
-
-    return {
-      ...o,
-      slots,
-    };
-  });
+export type AppAction = ActionSetConfig | ActionSetUser | ActionSetAlert;
 
 // Reducers
 export const appReducer = (state: AppState, action: AppAction): AppState => {
@@ -78,62 +15,8 @@ export const appReducer = (state: AppState, action: AppAction): AppState => {
       return { ...state, config: action.payload };
     case 'SET_USER':
       return { ...state, user: action.payload };
-    case 'SET_OFFICES':
-      return { ...state, offices: [...action.payload] };
-    case 'SET_CURRENT_OFFICE':
-      return { ...state, currentOffice: action.payload };
-    case 'SET_BOOKINGS':
-      return { ...state, bookings: [...action.payload] };
-    case 'ADD_BOOKING': {
-      const bookings = [action.payload];
-
-      if (state.bookings) {
-        bookings.push(...state.bookings);
-      }
-
-      return {
-        ...state,
-        bookings,
-      };
-    }
-    case 'REMOVE_BOOKING': {
-      const bookings = [];
-
-      if (state.bookings) {
-        bookings.push(...state.bookings.filter((b) => b.id !== action.payload));
-      }
-
-      return {
-        ...state,
-        bookings,
-      };
-    }
-    case 'INCREASE_OFFICE_SLOT': {
-      const { date, office } = action.payload;
-
-      return {
-        ...state,
-        offices: updateSlots(state.offices, office, date, 'increase'),
-      };
-    }
-    case 'DECREASE_OFFICE_SLOT': {
-      const { date, office } = action.payload;
-
-      return {
-        ...state,
-        offices: updateSlots(state.offices, office, date, 'decrease'),
-      };
-    }
-    case 'SET_ERROR':
-      if (action.payload) {
-        return { ...state, error: { message: action.payload, color: 'error' } };
-      }
-      return { ...state, error: undefined };
     case 'SET_ALERT':
-      if (action.payload) {
-        return { ...state, error: action.payload };
-      }
-      return { ...state, error: undefined };
+      return { ...state, alert: action.payload };
     default:
       return state;
   }

--- a/client/src/context/reducers.ts
+++ b/client/src/context/reducers.ts
@@ -1,12 +1,13 @@
 import { AppState, Config, Alert } from './stores';
-import { User } from '../types/api';
+import { User, Office } from '../types/api';
 
 // Types
 type ActionSetConfig = { type: 'SET_CONFIG'; payload: Config };
 type ActionSetUser = { type: 'SET_USER'; payload: User | undefined };
+type ActionSetOffice = { type: 'SET_OFFICE'; payload: Office['name'] | undefined };
 type ActionSetAlert = { type: 'SET_ALERT'; payload: Alert | undefined };
 
-export type AppAction = ActionSetConfig | ActionSetUser | ActionSetAlert;
+export type AppAction = ActionSetConfig | ActionSetUser | ActionSetOffice | ActionSetAlert;
 
 // Reducers
 export const appReducer = (state: AppState, action: AppAction): AppState => {
@@ -15,6 +16,8 @@ export const appReducer = (state: AppState, action: AppAction): AppState => {
       return { ...state, config: action.payload };
     case 'SET_USER':
       return { ...state, user: action.payload };
+    case 'SET_OFFICE':
+      return { ...state, office: action.payload };
     case 'SET_ALERT':
       return { ...state, alert: action.payload };
     default:

--- a/client/src/context/stores.ts
+++ b/client/src/context/stores.ts
@@ -3,7 +3,7 @@ import { Color } from '@material-ui/lab/Alert';
 
 import { AppAction } from './reducers';
 
-import { User } from '../types/api';
+import { User, Office } from '../types/api';
 
 // Types
 export type Alert = {
@@ -33,5 +33,6 @@ export type Config = {
 export type AppState = {
   config?: Config;
   user?: User;
+  office?: Office['name'];
   alert?: Alert;
 };

--- a/client/src/context/stores.ts
+++ b/client/src/context/stores.ts
@@ -1,10 +1,16 @@
 import { Dispatch } from 'react';
-
-import { AppAction } from './reducers';
-import { User, Office, Booking } from '../types/api';
 import { Color } from '@material-ui/lab/Alert';
 
+import { AppAction } from './reducers';
+
+import { User } from '../types/api';
+
 // Types
+export type Alert = {
+  message: string;
+  color: Color;
+};
+
 export type AppStore = {
   state: AppState;
   dispatch: Dispatch<AppAction>;
@@ -26,19 +32,6 @@ export type Config = {
 
 export type AppState = {
   config?: Config;
-  user: User | undefined;
-  offices: Office[];
-  currentOffice: Office | undefined;
-  bookings: Booking[] | undefined;
-  error?: { message: string; color: Color };
-};
-
-// State
-export const initialAppState: AppState = {
-  config: undefined,
-  user: undefined,
-  offices: [],
-  currentOffice: undefined,
-  bookings: undefined,
-  error: undefined,
+  user?: User;
+  alert?: Alert;
 };


### PR DESCRIPTION
This has turned into a significant change, so I would recommend a video call with you both to talk through the changes I've made, why, and to do another round of testing.

In short, I have **removed** global state for:

- All offices
- All user bookings
- Selected office

The selected office is still in global state, but in the simpler form of just the office name.

The main driver for this change was due to data issues when switching from the admin to user views.  Persisting those changes when the bookings retrieved on the admin may be different to the globally stored user bookings was challenging.  

The decision was made to re-retrieve the data from the DB on each relevant page load, to make sure we had the latest data - considering it can be updated by other users of the app.  With this in mind, the globally stored data was no longer required, and as a result the code is (in my opinion) shorter and easier to understand.  I have still limited the number of DB calls where possible.

As a result, any changes made on the admin screen, or by other admins, or bookings from other users, will all be reflected every time you visit the home page, regardless of refreshing the browser.

Separate to this, it may be worth adding some timeout code to certain pages (possibly just the home page) to auto-refresh after a period of time to make sure the availability of kept up-to-date.  I have concerns that some users may just leave the page open indefinitely, and as a result it will show out-dated information.