### PR TITLE
Fix Cognito email case sensitivity

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -152,6 +152,9 @@ const userPool = new aws.cognito.UserPool(`${serviceName}-users`, {
     requireUppercase: false,
   },
   usernameAttributes: ['email'],
+  usernameConfiguration: {
+    caseSensitive: caseSensitiveEmail,
+  },
   mfaConfiguration: 'OFF',
   lambdaConfig: {
     createAuthChallenge: createAuthChallenge.arn,


### PR DESCRIPTION
- Use configuration to set if emails should be case sensitive.

Fixes #57

To consider: Deploying this will cause the user pool to be re-created. All users will have to log in again. Anyone who hasn't refreshed the app will get "not authorized" errors displayed.