### PR TITLE
Create stable office ids

### DIFF
--- a/client/src/components/App/Admin/Bookings.tsx
+++ b/client/src/components/App/Admin/Bookings.tsx
@@ -93,7 +93,7 @@ const Bookings: React.FC<RouteComponentProps> = () => {
   // Helpers
   const getAllBookings = useCallback(() => {
     if (selectedOffice) {
-      getBookings({ office: selectedOffice.name, date: format(selectedDate, 'yyyy-MM-dd') })
+      getBookings({ office: selectedOffice, date: format(selectedDate, 'yyyy-MM-dd') })
         .then((data) => setDbBookings(data))
         .catch((err) => {
           // Handle errors

--- a/client/src/components/App/Admin/Bookings.tsx
+++ b/client/src/components/App/Admin/Bookings.tsx
@@ -40,7 +40,7 @@ import { OurButton } from '../../../styles/MaterialComponents';
 
 import { getBookings, cancelBooking, getOffices } from '../../../lib/api';
 import { formatError } from '../../../lib/app';
-import { Booking, Office } from '../../../types/api';
+import { Booking, OfficeWithSlots, Office } from '../../../types/api';
 
 import BookingStyles from './Bookings.styles';
 
@@ -111,7 +111,7 @@ const Bookings: React.FC<RouteComponentProps> = () => {
   }, [selectedOffice, selectedDate, dispatch]);
 
   const findOffice = useCallback(
-    (name: Office['name']) => offices && offices.find((o) => o.name === name),
+    (name: OfficeWithSlots['name']) => offices && offices.find((o) => o.name === name),
     [offices]
   );
 
@@ -123,7 +123,9 @@ const Bookings: React.FC<RouteComponentProps> = () => {
         .then((data) =>
           setOffices(
             data.filter((office) =>
-              user.permissions.officesCanManageBookingsFor.includes(office.name)
+              user.permissions.officesCanManageBookingsFor.find(
+                (userOffice) => userOffice.name === office.name
+              )
             )
           )
         )
@@ -145,7 +147,7 @@ const Bookings: React.FC<RouteComponentProps> = () => {
   useEffect(() => {
     if (user && offices && offices.length > 0 && !selectedOffice) {
       // Retrieve first office user can manage bookings for
-      setSelectedOffice(findOffice(user.permissions.officesCanManageBookingsFor[0]));
+      setSelectedOffice(user.permissions.officesCanManageBookingsFor[0]);
     }
   }, [user, offices, selectedOffice, findOffice]);
 
@@ -245,8 +247,8 @@ const Bookings: React.FC<RouteComponentProps> = () => {
                       onChange={(e) => setSelectedOffice(findOffice(e.target.value as string))}
                     >
                       {user.permissions.officesCanManageBookingsFor.map((office, index) => (
-                        <MenuItem value={office} key={index}>
-                          {office}
+                        <MenuItem value={office.name} key={index}>
+                          {office.name}
                         </MenuItem>
                       ))}
                     </Select>

--- a/client/src/components/App/Admin/Bookings.tsx
+++ b/client/src/components/App/Admin/Bookings.tsx
@@ -367,7 +367,7 @@ const Bookings: React.FC<RouteComponentProps> = () => {
               <DialogContentText>
                 Booking for <strong>{bookingToCancel.user}</strong> on{' '}
                 <strong>{format(parseISO(bookingToCancel.date), 'do LLLL')}</strong> for{' '}
-                <strong>{bookingToCancel.office}</strong>
+                <strong>{bookingToCancel.office.name}</strong>
               </DialogContentText>
             </DialogContent>
             <DialogActions>

--- a/client/src/components/App/Admin/CreateBooking.tsx
+++ b/client/src/components/App/Admin/CreateBooking.tsx
@@ -20,7 +20,7 @@ import { OurButton } from '../../../styles/MaterialComponents';
 
 import { getOffices, createBooking } from '../../../lib/api';
 import { formatError } from '../../../lib/app';
-import { OfficeSlot, Office } from '../../../types/api';
+import { OfficeSlot, OfficeWithSlots } from '../../../types/api';
 import { validateEmail } from '../../../lib/emailValidation';
 
 import CreateBookingStyles from './CreateBooking.styles';
@@ -32,8 +32,8 @@ const AdminCreateBooking: React.FC<RouteComponentProps> = () => {
 
   // Local state
   const [loading, setLoading] = useState(false);
-  const [offices, setOffices] = useState<Office[] | undefined>();
-  const [selectedOffice, setSelectedOffice] = useState<Office | undefined>();
+  const [offices, setOffices] = useState<OfficeWithSlots[] | undefined>();
+  const [selectedOffice, setSelectedOffice] = useState<OfficeWithSlots | undefined>();
   const [officeSlot, setOfficeSlot] = useState<OfficeSlot | undefined>();
   const [bookingDate, setBookingDate] = useState(addDays(new Date(), +1));
   const [email, setEmail] = useState('');
@@ -41,7 +41,7 @@ const AdminCreateBooking: React.FC<RouteComponentProps> = () => {
 
   // Helpers
   const findOffice = useCallback(
-    (name: Office['name']) => offices && offices.find((o) => o.name === name),
+    (name: OfficeWithSlots['name']) => offices && offices.find((o) => o.name === name),
     [offices]
   );
 
@@ -53,7 +53,9 @@ const AdminCreateBooking: React.FC<RouteComponentProps> = () => {
         .then((data) =>
           setOffices(
             data.filter((office) =>
-              user.permissions.officesCanManageBookingsFor.includes(office.name)
+              user.permissions.officesCanManageBookingsFor.find(
+                (userOffice) => userOffice.name === office.name
+              )
             )
           )
         )
@@ -75,7 +77,7 @@ const AdminCreateBooking: React.FC<RouteComponentProps> = () => {
   useEffect(() => {
     if (user && offices && offices.length > 0 && !selectedOffice) {
       // Retrieve first office user can manage bookings for
-      setSelectedOffice(findOffice(user.permissions.officesCanManageBookingsFor[0]));
+      setSelectedOffice(findOffice(user.permissions.officesCanManageBookingsFor[0].name));
     }
   }, [user, offices, selectedOffice, findOffice]);
 

--- a/client/src/components/App/Admin/CreateBooking.tsx
+++ b/client/src/components/App/Admin/CreateBooking.tsx
@@ -156,7 +156,7 @@ const AdminCreateBooking: React.FC<RouteComponentProps> = () => {
     // Submit
     const formattedDate = format(bookingDate, 'yyyy-MM-dd');
 
-    createBooking(email, formattedDate, selectedOffice.name, parking)
+    createBooking(email, formattedDate, selectedOffice, parking)
       .then(() => {
         // Increase office quota
         // This assumes the date and selected office haven't changed

--- a/client/src/components/App/Admin/User.tsx
+++ b/client/src/components/App/Admin/User.tsx
@@ -15,7 +15,7 @@ import AdminLayout from './Layout/Layout';
 import { OurButton } from '../../../styles/MaterialComponents';
 import Loading from '../../Assets/LoadingSpinner';
 
-import { getUser, putUser, getOffices } from '../../../lib/api';
+import { getUser, putUser } from '../../../lib/api';
 import { formatError } from '../../../lib/app';
 import { User, Office } from '../../../types/api';
 
@@ -64,26 +64,7 @@ const UserAdmin: React.FC<RouteComponentProps<{ email: string }>> = (props) => {
   useEffect(() => {
     if (user && selectedUser) {
       // Get all offices admin can manage
-      getOffices()
-        .then((data) =>
-          setOffices(
-            data.filter((office) =>
-              user.permissions.officesCanManageBookingsFor.includes(office.name)
-            )
-          )
-        )
-        .catch((err) => {
-          // Handle errors
-          setLoading(false);
-
-          dispatch({
-            type: 'SET_ALERT',
-            payload: {
-              message: formatError(err),
-              color: 'error',
-            },
-          });
-        });
+      setOffices(user.permissions.officesCanManageBookingsFor);
     }
   }, [user, selectedUser, dispatch]);
 
@@ -215,7 +196,9 @@ const UserAdmin: React.FC<RouteComponentProps<{ email: string }>> = (props) => {
                       disabled={!canEdit}
                       options={offices.map((o) => o.name)}
                       value={
-                        selectedUser.role.name === 'Office Admin' ? selectedUser.role.offices : []
+                        selectedUser.role.name === 'Office Admin'
+                          ? selectedUser.role.offices.map((office) => office.name)
+                          : []
                       }
                       onChange={(_e, value) =>
                         setSelectedUser((selectedUser) => {
@@ -225,7 +208,10 @@ const UserAdmin: React.FC<RouteComponentProps<{ email: string }>> = (props) => {
 
                           return {
                             ...selectedUser,
-                            role: { name: 'Office Admin', offices: value },
+                            role: {
+                              name: 'Office Admin',
+                              offices: offices.filter((office) => value.includes(office.name)),
+                            },
                           };
                         })
                       }

--- a/client/src/components/App/Help.tsx
+++ b/client/src/components/App/Help.tsx
@@ -62,7 +62,10 @@ const Help: React.FC<RouteComponentProps> = () => {
       getOffices()
         .then((data) => {
           // Validate and update local storage if not
-          const findOffice = data.find((o) => o.name === office);
+          const findOffice =
+            'id' in office
+              ? data.find((o) => o.id === office.id)
+              : data.find((o) => o.name === office.name);
 
           if (!findOffice) {
             dispatch({

--- a/client/src/components/App/Home.tsx
+++ b/client/src/components/App/Home.tsx
@@ -75,7 +75,10 @@ const Home: React.FC<RouteComponentProps> = () => {
       // Retrieve selected office
       if (office) {
         // Validate
-        const findOffice = allOffices.find((o) => o.name === office);
+        const findOffice =
+          'id' in office
+            ? allOffices.find((o) => o.id === office.id)
+            : allOffices.find((o) => o.name === office.name);
 
         if (findOffice) {
           setCurrentOffice(findOffice);
@@ -84,7 +87,7 @@ const Home: React.FC<RouteComponentProps> = () => {
           if (!office) {
             dispatch({
               type: 'SET_OFFICE',
-              payload: findOffice.name,
+              payload: findOffice,
             });
           }
         } else {

--- a/client/src/components/App/Home.tsx
+++ b/client/src/components/App/Home.tsx
@@ -22,7 +22,7 @@ const Home: React.FC<RouteComponentProps> = () => {
   const { user, office } = state;
 
   // Local state
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [refreshedAt, setRefreshedAt] = useState(new Date());
   const [allOffices, setAllOffices] = useState<Office[] | undefined>();
   const [currentOffice, setCurrentOffice] = useState<OfficeWithSlots | undefined>();
@@ -44,24 +44,25 @@ const Home: React.FC<RouteComponentProps> = () => {
   }, [dispatch]);
 
   useEffect(() => {
-    // Get all offices
     if (office === undefined) {
-      return;
-    }
-    if ('id' in office) {
-      setLoading(true);
+      setLoading(false);
+    } else if ('id' in office) {
       getOffice(office.id)
         .then(setCurrentOffice)
         .catch((err) => {
           dispatch({
-            type: 'SET_ALERT',
-            payload: {
-              message: formatError(err),
-              color: 'error',
-            },
+            type: 'SET_OFFICE',
+            payload: undefined,
           });
         })
         .then(() => setLoading(false));
+    }
+  }, [office, refreshedAt, dispatch]);
+
+  // TODO: Remove in a while once we're happy no-one's stored the old name version any more.
+  useEffect(() => {
+    if (office === undefined) {
+      return;
     }
     if ('name' in office && allOffices) {
       const newOffice = allOffices.find((o) => o.name === office.name);
@@ -73,8 +74,7 @@ const Home: React.FC<RouteComponentProps> = () => {
   }, [office, allOffices, refreshedAt, dispatch]);
 
   useEffect(() => {
-    if (user && refreshedAt) {
-      // Get users bookings
+    if (user) {
       getBookings({ user: user.email })
         .then((data) => setUserBookings(data))
         .catch((err) => {

--- a/client/src/components/App/Home.tsx
+++ b/client/src/components/App/Home.tsx
@@ -11,7 +11,7 @@ import MakeBooking from './Home/MakeBooking';
 
 import { getOffices, getBookings } from '../../lib/api';
 import { formatError } from '../../lib/app';
-import { Office, Booking } from '../../types/api';
+import { OfficeWithSlots, Booking } from '../../types/api';
 
 import HomeStyles from './Home.styles';
 
@@ -23,8 +23,8 @@ const Home: React.FC<RouteComponentProps> = () => {
 
   // Local state
   const [loading, setLoading] = useState(true);
-  const [allOffices, setAllOffices] = useState<Office[] | undefined>();
-  const [currentOffice, setCurrentOffice] = useState<Office | undefined>();
+  const [allOffices, setAllOffices] = useState<OfficeWithSlots[] | undefined>();
+  const [currentOffice, setCurrentOffice] = useState<OfficeWithSlots | undefined>();
   const [userBookings, setUserBookings] = useState<Booking[] | undefined>();
 
   // Helpers

--- a/client/src/components/App/Home/MakeBooking.tsx
+++ b/client/src/components/App/Home/MakeBooking.tsx
@@ -25,7 +25,7 @@ import { AppContext } from '../../AppProvider';
 import BookButton from '../../Assets/BookButton';
 import { OurButton } from '../../../styles/MaterialComponents';
 
-import { Booking, Office } from '../../../types/api';
+import { Booking, OfficeWithSlots } from '../../../types/api';
 import { createBooking, cancelBooking } from '../../../lib/api';
 import { formatError } from '../../../lib/app';
 import { DATE_FNS_OPTIONS } from '../../../constants/dates';
@@ -36,7 +36,7 @@ import BookingStatus from '../../Assets/BookingStatus';
 
 // Types
 type Props = {
-  office: Office;
+  office: OfficeWithSlots;
   bookings: Booking[];
   refreshBookings: () => void;
 };

--- a/client/src/components/App/Home/MakeBooking.tsx
+++ b/client/src/components/App/Home/MakeBooking.tsx
@@ -204,7 +204,7 @@ const MakeBooking: React.FC<Props> = (props) => {
 
   useEffect(() => {
     if (user && weeks && weeks.length > 0) {
-      const { name, quota: officeQuota, parkingQuota, slots } = office;
+      const { id, quota: officeQuota, parkingQuota, slots } = office;
       const { quota: userQuota } = user;
 
       const rows: Row[] = [];
@@ -239,7 +239,7 @@ const MakeBooking: React.FC<Props> = (props) => {
             const availableCarPark = parkingQuota - slot.bookedParking;
 
             // Find any user booking for this office/slot
-            const booking = bookings.find((b) => b.office === name && b.date === slot.date);
+            const booking = bookings.find((b) => b.office.id === id && b.date === slot.date);
 
             // Total user bookings for this week
             const userWeekBookings = bookings.filter((b) =>
@@ -267,7 +267,7 @@ const MakeBooking: React.FC<Props> = (props) => {
           } else {
             // Did we have a booking on this day?
             const booking = bookings.find(
-              (b) => b.office === name && b.date === format(d, 'y-MM-dd', DATE_FNS_OPTIONS)
+              (b) => b.office.id === id && b.date === format(d, 'y-MM-dd', DATE_FNS_OPTIONS)
             );
 
             // Not in range
@@ -330,7 +330,7 @@ const MakeBooking: React.FC<Props> = (props) => {
       // Create new booking
       const formattedDate = format(date, 'yyyy-MM-dd', DATE_FNS_OPTIONS);
 
-      createBooking(user.email, formattedDate, office.name, withParking)
+      createBooking(user.email, formattedDate, office, withParking)
         .then(() => refreshBookings())
         .catch((err) => {
           // Refresh DB

--- a/client/src/components/App/Home/NextBooking.tsx
+++ b/client/src/components/App/Home/NextBooking.tsx
@@ -46,7 +46,7 @@ const NextBooking: React.FC<Props> = (props) => {
           'do LLL',
           DATE_FNS_OPTIONS
         )}{' '}
-        <span>@</span> {todaysBooking.office}
+        <span>@</span> {todaysBooking.office.name}
       </h3>
 
       <OurButton

--- a/client/src/components/App/Home/WhichOffice.tsx
+++ b/client/src/components/App/Home/WhichOffice.tsx
@@ -21,7 +21,7 @@ const WhichOffice: React.FC<Props> = (props) => {
     // Update global state
     dispatch({
       type: 'SET_OFFICE',
-      payload: office.name,
+      payload: office,
     });
   };
 

--- a/client/src/components/App/Home/WhichOffice.tsx
+++ b/client/src/components/App/Home/WhichOffice.tsx
@@ -1,14 +1,14 @@
 import React, { useContext } from 'react';
 
 import { AppContext } from '../../AppProvider';
-import { OfficeWithSlots } from '../../../types/api';
+import { Office } from '../../../types/api';
 
 import { OurButton } from '../../../styles/MaterialComponents';
 import WhichOfficeStyles from './WhichOffice.styles';
 
 // Types
 type Props = {
-  offices: OfficeWithSlots[];
+  offices: Office[];
 };
 
 // Component
@@ -17,7 +17,7 @@ const WhichOffice: React.FC<Props> = (props) => {
   const { dispatch } = useContext(AppContext);
 
   // Handlers
-  const selectOffice = (office: OfficeWithSlots) => {
+  const selectOffice = (office: Office) => {
     // Update global state
     dispatch({
       type: 'SET_OFFICE',

--- a/client/src/components/App/Home/WhichOffice.tsx
+++ b/client/src/components/App/Home/WhichOffice.tsx
@@ -1,14 +1,14 @@
 import React, { useContext } from 'react';
 
 import { AppContext } from '../../AppProvider';
-import { Office } from '../../../types/api';
+import { OfficeWithSlots } from '../../../types/api';
 
 import { OurButton } from '../../../styles/MaterialComponents';
 import WhichOfficeStyles from './WhichOffice.styles';
 
 // Types
 type Props = {
-  offices: Office[];
+  offices: OfficeWithSlots[];
 };
 
 // Component
@@ -17,7 +17,7 @@ const WhichOffice: React.FC<Props> = (props) => {
   const { dispatch } = useContext(AppContext);
 
   // Handlers
-  const selectOffice = (office: Office) => {
+  const selectOffice = (office: OfficeWithSlots) => {
     // Update global state
     dispatch({
       type: 'SET_OFFICE',

--- a/client/src/components/App/ViewBooking.tsx
+++ b/client/src/components/App/ViewBooking.tsx
@@ -98,7 +98,7 @@ const ViewBooking: React.FC<RouteComponentProps<Props>> = (props) => {
                 )}
               </h2>
 
-              <h3>{booking.office}</h3>
+              <h3>{booking.office.name}</h3>
               {booking.parking && <p className="parking">+ parking</p>}
 
               <div className="breaker"></div>

--- a/client/src/context/reducers.ts
+++ b/client/src/context/reducers.ts
@@ -1,10 +1,10 @@
 import { AppState, Config, Alert } from './stores';
-import { User, Office } from '../types/api';
+import { User, OfficeWithSlots } from '../types/api';
 
 // Types
 type ActionSetConfig = { type: 'SET_CONFIG'; payload: Config };
 type ActionSetUser = { type: 'SET_USER'; payload: User | undefined };
-type ActionSetOffice = { type: 'SET_OFFICE'; payload: Office['name'] | undefined };
+type ActionSetOffice = { type: 'SET_OFFICE'; payload: OfficeWithSlots['name'] | undefined };
 type ActionSetAlert = { type: 'SET_ALERT'; payload: Alert | undefined };
 
 export type AppAction = ActionSetConfig | ActionSetUser | ActionSetOffice | ActionSetAlert;

--- a/client/src/context/reducers.ts
+++ b/client/src/context/reducers.ts
@@ -1,10 +1,10 @@
 import { AppState, Config, Alert } from './stores';
-import { User, OfficeWithSlots } from '../types/api';
+import { User } from '../types/api';
 
 // Types
 type ActionSetConfig = { type: 'SET_CONFIG'; payload: Config };
 type ActionSetUser = { type: 'SET_USER'; payload: User | undefined };
-type ActionSetOffice = { type: 'SET_OFFICE'; payload: OfficeWithSlots['name'] | undefined };
+type ActionSetOffice = { type: 'SET_OFFICE'; payload: { id: string } | undefined };
 type ActionSetAlert = { type: 'SET_ALERT'; payload: Alert | undefined };
 
 export type AppAction = ActionSetConfig | ActionSetUser | ActionSetOffice | ActionSetAlert;
@@ -21,10 +21,11 @@ export const appReducer = (state: AppState, action: AppAction): AppState => {
 
       // Update local storage
       if (office) {
-        localStorage.setItem('office', office);
+        localStorage.setItem('officeId', office.id);
       } else {
-        localStorage.removeItem('office');
+        localStorage.removeItem('officeId');
       }
+      localStorage.removeItem('office');
 
       return { ...state, office };
     case 'SET_ALERT':

--- a/client/src/context/reducers.ts
+++ b/client/src/context/reducers.ts
@@ -27,7 +27,7 @@ export const appReducer = (state: AppState, action: AppAction): AppState => {
       }
       localStorage.removeItem('office');
 
-      return { ...state, office };
+      return { ...state, office: office ? { id: office.id } : undefined };
     case 'SET_ALERT':
       return { ...state, alert: action.payload };
     default:

--- a/client/src/context/stores.ts
+++ b/client/src/context/stores.ts
@@ -3,7 +3,7 @@ import { Color } from '@material-ui/lab/Alert';
 
 import { AppAction } from './reducers';
 
-import { User, OfficeWithSlots } from '../types/api';
+import { User } from '../types/api';
 
 // Types
 export type Alert = {
@@ -33,11 +33,21 @@ export type Config = {
 export type AppState = {
   config?: Config;
   user?: User;
-  office?: OfficeWithSlots['name'];
+  office?: { name: string } | { id: string };
   alert?: Alert;
 };
 
 // Initial state
 export const appInitialState: AppState = {
-  office: localStorage.getItem('office') || undefined,
+  office: (() => {
+    const officeId = localStorage.getItem('officeId');
+    const officeName = localStorage.getItem('office');
+    if (officeId !== null) {
+      return { id: officeId };
+    }
+    if (officeName !== null) {
+      return { name: officeName };
+    }
+    return undefined;
+  })(),
 };

--- a/client/src/context/stores.ts
+++ b/client/src/context/stores.ts
@@ -3,7 +3,7 @@ import { Color } from '@material-ui/lab/Alert';
 
 import { AppAction } from './reducers';
 
-import { User, Office } from '../types/api';
+import { User, OfficeWithSlots } from '../types/api';
 
 // Types
 export type Alert = {
@@ -33,7 +33,7 @@ export type Config = {
 export type AppState = {
   config?: Config;
   user?: User;
-  office?: Office['name'];
+  office?: OfficeWithSlots['name'];
   alert?: Alert;
 };
 

--- a/client/src/context/stores.ts
+++ b/client/src/context/stores.ts
@@ -33,7 +33,7 @@ export type Config = {
 export type AppState = {
   config?: Config;
   user?: User;
-  office?: { name: string } | { id: string };
+  office?: { name: string } | { id: string }; // TODO: Remove name option once we're happy most people have moved over to using the ID.
   alert?: Alert;
 };
 
@@ -41,10 +41,11 @@ export type AppState = {
 export const appInitialState: AppState = {
   office: (() => {
     const officeId = localStorage.getItem('officeId');
-    const officeName = localStorage.getItem('office');
     if (officeId !== null) {
       return { id: officeId };
     }
+    // TODO: Remove once we're happy most people have moved over to using the ID.
+    const officeName = localStorage.getItem('office');
     if (officeName !== null) {
       return { name: officeName };
     }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -133,6 +133,23 @@ export const getUserCached = async (email: string): Promise<User> => {
   }
 };
 
+export const getOffice = async (officeId: string): Promise<OfficeWithSlots> => {
+  const url = new URL(`offices/${officeId}`, BASE_URL);
+
+  const headers = await buildHeaders();
+
+  const response = await fetch(url.href, {
+    method: 'GET',
+    headers,
+  });
+
+  if (!response.ok) {
+    throw await buildHttpError(response);
+  }
+
+  return await response.json();
+};
+
 export const getOffices = async (): Promise<OfficeWithSlots[]> => {
   const url = new URL('offices', BASE_URL);
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,7 +1,7 @@
 import { getAuthorization } from './auth';
 import {
   User,
-  Office,
+  OfficeWithSlots,
   Booking,
   UserQuery,
   DefaultRole,
@@ -132,7 +132,7 @@ export const getUserCached = async (email: string): Promise<User> => {
   }
 };
 
-export const getOffices = async (): Promise<Office[]> => {
+export const getOffices = async (): Promise<OfficeWithSlots[]> => {
   const url = new URL('offices', BASE_URL);
 
   const headers = await buildHeaders();
@@ -183,7 +183,7 @@ export const getBookings = async ({
 export const createBooking = async (
   user: User['email'],
   date: string,
-  office: Office['name'],
+  office: OfficeWithSlots['name'],
   parking?: boolean
 ): Promise<Booking> => {
   const url = new URL('bookings', BASE_URL);

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -7,6 +7,7 @@ import {
   DefaultRole,
   OfficeAdminRole,
   UserQueryResponse,
+  Office,
 } from '../types/api';
 
 // Constants
@@ -183,7 +184,7 @@ export const getBookings = async ({
 export const createBooking = async (
   user: User['email'],
   date: string,
-  office: OfficeWithSlots['name'],
+  office: Pick<Office, 'id'>,
   parking?: boolean
 ): Promise<Booking> => {
   const url = new URL('bookings', BASE_URL);

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -150,7 +150,7 @@ export const getOffice = async (officeId: string): Promise<OfficeWithSlots> => {
   return await response.json();
 };
 
-export const getOffices = async (): Promise<OfficeWithSlots[]> => {
+export const getOffices = async (): Promise<Office[]> => {
   const url = new URL('offices', BASE_URL);
 
   const headers = await buildHeaders();

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -154,13 +154,13 @@ export const getBookings = async ({
   user,
   office,
   date,
-}: { user?: string; office?: string; date?: string } = {}): Promise<Booking[]> => {
+}: { user?: string; office?: { id: string }; date?: string } = {}): Promise<Booking[]> => {
   const params = new URLSearchParams();
   if (user !== undefined) {
     params.set('user', user);
   }
   if (office !== undefined) {
-    params.set('office', office);
+    params.set('office', office.id);
   }
   if (date !== undefined) {
     params.set('date', date);

--- a/client/src/lib/emailValidation.ts
+++ b/client/src/lib/emailValidation.ts
@@ -1,6 +1,6 @@
 /** Source: https://emailregex.com/ */
 // eslint-disable-next-line
-const validEmailRegex = /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/g.compile();
+const validEmailRegex = /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
 
 export const validateEmail = (emailRegex: string | undefined, email: string): boolean => {
   if (!validEmailRegex.test(email)) {

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -3,9 +3,16 @@ export type UserWeeklyBooking = {
   booked: number;
 };
 
+export type Office = {
+  id: string;
+  name: string;
+  quota: number;
+  parkingQuota: number;
+};
+
 export type DefaultRole = { name: 'Default' };
 export type SystemAdminRole = { name: 'System Admin' };
-export type OfficeAdminRole = { name: 'Office Admin'; offices: string[] };
+export type OfficeAdminRole = { name: 'Office Admin'; offices: Office[] };
 export type UserRole = DefaultRole | SystemAdminRole | OfficeAdminRole;
 
 export type UserQuery = { quota?: 'custom'; role?: UserRole['name']; emailPrefix?: string };
@@ -21,7 +28,7 @@ export type User = {
     canViewUsers: boolean;
     canEditUsers: boolean;
     canManageAllBookings: boolean;
-    officesCanManageBookingsFor: string[];
+    officesCanManageBookingsFor: Office[];
   };
 };
 
@@ -31,10 +38,7 @@ export type OfficeSlot = {
   bookedParking: number;
 };
 
-export type Office = {
-  name: string;
-  quota: number;
-  parkingQuota: number;
+export type OfficeWithSlots = Office & {
   slots: OfficeSlot[];
 };
 
@@ -42,6 +46,6 @@ export type Booking = {
   id: string;
   user: User['email'];
   date: string;
-  office: Office['name'];
+  office: OfficeWithSlots['name'];
   parking: boolean;
 };

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -46,6 +46,6 @@ export type Booking = {
   id: string;
   user: User['email'];
   date: string;
-  office: OfficeWithSlots['name'];
+  office: Office;
   parking: boolean;
 };

--- a/server/app.ts
+++ b/server/app.ts
@@ -9,7 +9,7 @@ import { putUser } from './users/putUser';
 import { isCreateBooking, mapBookings } from './bookings/model';
 import { createBooking } from './bookings/createBooking';
 import { getUserBookings } from './db/bookings';
-import { getOffices } from './getOffices';
+import { getOffices, getOffice } from './getOffices';
 import { deleteBooking } from './bookings/deleteBooking';
 import { errorResponse, HttpError, Forbidden, NotFound } from './errors';
 import { queryBookings } from './bookings/queryBookings';
@@ -91,6 +91,16 @@ export const configureApp = (config: Config) => {
     try {
       const combined = await getOffices(config);
       return res.json(combined);
+    } catch (err) {
+      return next(err);
+    }
+  });
+
+  app.get('/api/offices/:officeId', async (req, res, next) => {
+    try {
+      const officeId = req.params.officeId;
+      const office = await getOffice(config, officeId);
+      return res.json(office);
     } catch (err) {
       return next(err);
     }

--- a/server/app.ts
+++ b/server/app.ts
@@ -78,7 +78,7 @@ export const configureApp = (config: Config) => {
       const testUserEmail = normaliseEmail(config.selfTestUser);
       const offices = await getOffices(config);
       const user = await getUser(config, testUserEmail);
-      const bookings = mapBookings(await getUserBookings(config, testUserEmail));
+      const bookings = mapBookings(config, await getUserBookings(config, testUserEmail));
       return res.json({ offices, user, bookings });
     } catch (error) {
       return next(error);

--- a/server/app.ts
+++ b/server/app.ts
@@ -9,7 +9,7 @@ import { putUser } from './users/putUser';
 import { isCreateBooking, mapBookings } from './bookings/model';
 import { createBooking } from './bookings/createBooking';
 import { getUserBookings } from './db/bookings';
-import { getOffices, getOffice } from './getOffices';
+import { getOffice } from './getOffices';
 import { deleteBooking } from './bookings/deleteBooking';
 import { errorResponse, HttpError, Forbidden, NotFound } from './errors';
 import { queryBookings } from './bookings/queryBookings';
@@ -76,10 +76,10 @@ export const configureApp = (config: Config) => {
         throw new Forbidden(`Incorrect self-test key`);
       }
       const testUserEmail = normaliseEmail(config.selfTestUser);
-      const offices = await getOffices(config);
+      const office = getOffice(config, config.officeQuotas[0].id);
       const user = await getUser(config, testUserEmail);
       const bookings = mapBookings(config, await getUserBookings(config, testUserEmail));
-      return res.json({ offices, user, bookings });
+      return res.json({ office, user, bookings });
     } catch (error) {
       return next(error);
     }
@@ -89,8 +89,7 @@ export const configureApp = (config: Config) => {
 
   app.get('/api/offices', async (_req, res, next) => {
     try {
-      const combined = await getOffices(config);
-      return res.json(combined);
+      return res.json(config.officeQuotas);
     } catch (err) {
       return next(err);
     }

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,6 +1,6 @@
 import express, { Response, Request, NextFunction } from 'express';
 import morgan from 'morgan';
-import { Config } from './app-config';
+import { Config, OfficeQuota } from './app-config';
 
 import { configureAuth, getAuthUserEmail } from './auth';
 import { getUser, isPutUserBody, isValidEmail } from './users/model';
@@ -177,7 +177,7 @@ export const configureApp = (config: Config) => {
         return { email };
       };
 
-      const parseOffice = (): { office?: string } => {
+      const parseOffice = (): { office?: OfficeQuota } => {
         const officeQuery = req.query.office as unknown;
         if (typeof officeQuery === 'undefined') {
           return {};
@@ -185,7 +185,11 @@ export const configureApp = (config: Config) => {
         if (typeof officeQuery !== 'string') {
           throw new HttpError({ httpMessage: 'Invalid office type', status: 400 });
         }
-        return { office: officeQuery };
+        const office = config.officeQuotas.find((o) => o.id === officeQuery);
+        if (office === undefined) {
+          throw new HttpError({ httpMessage: 'Unknown office query', status: 400 });
+        }
+        return { office };
       };
 
       const parseDate = (): { date?: string } => {

--- a/server/bookings/createBooking.ts
+++ b/server/bookings/createBooking.ts
@@ -6,7 +6,7 @@ import { getAvailableDates, dateStartOfWeek } from '../availableDates';
 import {
   incrementOfficeBookingCount,
   decrementOfficeBookingCount,
-  getOfficeBookings,
+  getOfficesBookings,
 } from '../db/officeBookings';
 import { incrementUserBookingCount, decrementUserBookingCount } from '../db/userBookings';
 import { Forbidden, HttpError } from '../errors';
@@ -76,7 +76,11 @@ export const createBooking = async (
   const userEmail = newBooking.user.toLocaleLowerCase();
   const startOfWeek = dateStartOfWeek(newBooking.date);
 
-  const officeBookings = await getOfficeBookings(config, [newBooking.date], [requestedOffice.name]);
+  const officeBookings = await getOfficesBookings(
+    config,
+    [newBooking.date],
+    [requestedOffice.name]
+  );
   const isQuotaExceeded = officeBookings[0]?.bookingCount >= requestedOffice.quota;
   const isParkingExceeded =
     newBooking.parking && officeBookings[0]?.parkingCount >= requestedOffice.parkingQuota;

--- a/server/bookings/createBooking.ts
+++ b/server/bookings/createBooking.ts
@@ -30,7 +30,9 @@ export const createBooking = async (
   const isAuthorised =
     request.user === currentUser.email ||
     currentUser.permissions.canManageAllBookings ||
-    currentUser.permissions.officesCanManageBookingsFor.includes(request.office);
+    currentUser.permissions.officesCanManageBookingsFor.find(
+      (office) => office.name === request.office
+    ) !== undefined;
 
   if (!isAuthorised) {
     throw new Forbidden();

--- a/server/bookings/createBooking.ts
+++ b/server/bookings/createBooking.ts
@@ -31,7 +31,7 @@ export const createBooking = async (
     request.user === currentUser.email ||
     currentUser.permissions.canManageAllBookings ||
     currentUser.permissions.officesCanManageBookingsFor.find(
-      (office) => office.name === request.office
+      (office) => office.id === request.office.id
     ) !== undefined;
 
   if (!isAuthorised) {
@@ -55,7 +55,7 @@ export const createBooking = async (
     });
   }
 
-  const requestedOffice = config.officeQuotas.find((office) => office.name === request.office);
+  const requestedOffice = config.officeQuotas.find((office) => office.id === request.office.id);
   if (!requestedOffice) {
     throw new HttpError({
       internalMessage: `Office not found: ${request.office}`,
@@ -70,6 +70,7 @@ export const createBooking = async (
     ...request,
     id,
     parking: request.parking ?? false,
+    office: requestedOffice.name,
   };
 
   const userEmail = newBooking.user.toLocaleLowerCase();
@@ -171,5 +172,5 @@ export const createBooking = async (
   }
 
   audit('4:Completed');
-  return mapBooking(createdBooking);
+  return mapBooking(config, createdBooking);
 };

--- a/server/bookings/createBooking.ts
+++ b/server/bookings/createBooking.ts
@@ -6,7 +6,7 @@ import { getAvailableDates, dateStartOfWeek } from '../availableDates';
 import {
   incrementOfficeBookingCount,
   decrementOfficeBookingCount,
-  getOfficesBookings,
+  getOfficeBookings,
 } from '../db/officeBookings';
 import { incrementUserBookingCount, decrementUserBookingCount } from '../db/userBookings';
 import { Forbidden, HttpError } from '../errors';
@@ -76,11 +76,7 @@ export const createBooking = async (
   const userEmail = newBooking.user.toLocaleLowerCase();
   const startOfWeek = dateStartOfWeek(newBooking.date);
 
-  const officeBookings = await getOfficesBookings(
-    config,
-    [newBooking.date],
-    [requestedOffice.name]
-  );
+  const officeBookings = await getOfficeBookings(config, requestedOffice.name, [newBooking.date]);
   const isQuotaExceeded = officeBookings[0]?.bookingCount >= requestedOffice.quota;
   const isParkingExceeded =
     newBooking.parking && officeBookings[0]?.parkingCount >= requestedOffice.parkingQuota;

--- a/server/bookings/deleteBooking.ts
+++ b/server/bookings/deleteBooking.ts
@@ -20,7 +20,9 @@ const audit = (step: string, details?: any) =>
 
 const canManageBooking = (authUser: User, booking: BookingsModel) =>
   authUser.permissions.canManageAllBookings ||
-  authUser.permissions.officesCanManageBookingsFor.includes(booking.office);
+  authUser.permissions.officesCanManageBookingsFor.find(
+    (office) => office.name === booking.office
+  ) !== undefined;
 
 export const deleteBooking = async (
   config: Config,

--- a/server/bookings/model.ts
+++ b/server/bookings/model.ts
@@ -1,17 +1,21 @@
 import { parseISO } from 'date-fns';
 import { BookingsModel as DbBooking } from '../db/bookings';
+import { OfficeQuota, Config } from '../app-config';
+import { Arrays } from 'collection-fns';
 
 export type CreateBooking = {
   user: string;
   date: string;
-  office: string;
+  office: { id: string };
   parking?: boolean;
 };
 
 export const isCreateBooking = (arg: any): arg is CreateBooking =>
   typeof arg.user === 'string' &&
   typeof arg.date === 'string' &&
-  typeof arg.office === 'string' &&
+  typeof arg.office === 'object' &&
+  'id' in arg.office &&
+  typeof arg.office.id === 'string' &&
   (typeof arg.parking === 'undefined' || typeof arg.parking === 'boolean');
 
 export type Booking = {
@@ -19,7 +23,7 @@ export type Booking = {
   created: string;
   user: string;
   date: string;
-  office: string;
+  office: OfficeQuota;
   lastCancellation: string;
   parking: boolean;
 };
@@ -29,14 +33,15 @@ const lastCancelTime = '00:00:00';
 export const getBookingLastCancelTime = (date: string) =>
   parseISO(`${date}T${lastCancelTime}`).toISOString();
 
-export const mapBooking = (booking: DbBooking): Booking => ({
+export const mapBooking = (config: Config, booking: DbBooking): Booking => ({
   id: booking.id,
   created: booking.created,
   user: booking.user,
   date: booking.date,
-  office: booking.office,
+  office: Arrays.get(config.officeQuotas, (office) => office.name === booking.office),
   lastCancellation: getBookingLastCancelTime(booking.date),
   parking: booking.parking,
 });
 
-export const mapBookings = (bookings: DbBooking[]): Booking[] => bookings.map(mapBooking);
+export const mapBookings = (config: Config, bookings: DbBooking[]): Booking[] =>
+  bookings.map((booking) => mapBooking(config, booking));

--- a/server/bookings/queryBookings.ts
+++ b/server/bookings/queryBookings.ts
@@ -32,15 +32,15 @@ export const queryBookings = async (config: Config, currentUser: User, query: Bo
 
   if (query.email) {
     const userBookings = await getUserBookings(config, query.email);
-    return mapBookings(userBookings.filter(filterBookings));
+    return mapBookings(config, userBookings.filter(filterBookings));
   } else if (query.office !== undefined) {
     const officeBookings = await queryBookingsDb(config, {
       office: query.office,
       date: query.date,
     });
-    return mapBookings(officeBookings.filter(filterBookings));
+    return mapBookings(config, officeBookings.filter(filterBookings));
   } else {
     const allBookings = await getAllBookings(config);
-    return mapBookings(allBookings.filter(filterBookings));
+    return mapBookings(config, allBookings.filter(filterBookings));
   }
 };

--- a/server/bookings/queryBookings.ts
+++ b/server/bookings/queryBookings.ts
@@ -15,7 +15,10 @@ export const queryBookings = async (config: Config, currentUser: User, query: Bo
   const isQueryingSelf = query.email && query.email === currentUser.email;
   const isOfficeAdmin =
     query.office !== undefined &&
-    currentUser.permissions.officesCanManageBookingsFor.includes(query.office);
+    currentUser.permissions.officesCanManageBookingsFor.find(
+      (office) => office.name === query.office
+    ) !== undefined;
+
   const isAuthorised =
     isQueryingSelf || isOfficeAdmin || currentUser.permissions.canManageAllBookings;
   if (!isAuthorised) {

--- a/server/db/bookings.ts
+++ b/server/db/bookings.ts
@@ -72,7 +72,7 @@ export const queryBookings = async (
 export const getAllBookings = async (config: Config): Promise<BookingsModel[]> => {
   const mapper = buildMapper(config);
   const rows: BookingsModel[] = [];
-  for await (const item of mapper.scan(BookingsModel, { limit: 500 })) {
+  for await (const item of mapper.scan(BookingsModel)) {
     rows.push(item);
   }
   return rows;

--- a/server/db/officeBookings.ts
+++ b/server/db/officeBookings.ts
@@ -146,7 +146,7 @@ export const decrementOfficeBookingCount = async (
     .promise();
 };
 
-export const getOfficeBookings = async (
+export const getOfficesBookings = async (
   config: Config,
   dates: string[],
   offices: string[]

--- a/server/getOffices.ts
+++ b/server/getOffices.ts
@@ -21,6 +21,7 @@ export const getOffices = async (config: Config) => {
     officeBookings.map((officeBooking) => [officeBooking.name + officeBooking.date, officeBooking])
   );
   const combined = config.officeQuotas.map((office) => ({
+    id: office.id,
     name: office.name,
     quota: office.quota,
     parkingQuota: office.parkingQuota,

--- a/server/getOffices.ts
+++ b/server/getOffices.ts
@@ -1,6 +1,7 @@
-import { getOfficesBookings } from './db/officeBookings';
+import { getOfficesBookings, getOfficeBookings } from './db/officeBookings';
 import { getAvailableDates } from './availableDates';
 import { Config } from './app-config';
+import { NotFound } from './errors';
 
 export const getOfficeId = (officeName: string): string => {
   const lowered = officeName.toLowerCase();
@@ -9,6 +10,33 @@ export const getOfficeId = (officeName: string): string => {
 
 const officeIdPattern = new RegExp('^[a-z0-9-]+$').compile();
 export const isValidOfficeId = (officeId: string): boolean => officeIdPattern.test(officeId);
+
+export const getOffice = async (config: Config, officeId: string) => {
+  const availableDates = getAvailableDates(config);
+  const office = config.officeQuotas.find((o) => o.id === officeId);
+  if (office === undefined) {
+    throw new NotFound();
+  }
+  const officeBookings = await getOfficeBookings(config, office.name, availableDates);
+  const indexedBookings = new Map(
+    officeBookings.map((officeBooking) => [officeBooking.date, officeBooking])
+  );
+  const combined = {
+    id: office.id,
+    name: office.name,
+    quota: office.quota,
+    parkingQuota: office.parkingQuota,
+    slots: availableDates.map((date) => {
+      const booking = indexedBookings.get(date);
+      return {
+        date,
+        booked: booking?.bookingCount ?? 0,
+        bookedParking: booking?.parkingCount ?? 0,
+      };
+    }),
+  };
+  return combined;
+};
 
 export const getOffices = async (config: Config) => {
   const availableDates = getAvailableDates(config);

--- a/server/getOffices.ts
+++ b/server/getOffices.ts
@@ -1,4 +1,4 @@
-import { getOfficeBookings } from './db/officeBookings';
+import { getOfficesBookings } from './db/officeBookings';
 import { getAvailableDates } from './availableDates';
 import { Config } from './app-config';
 
@@ -12,7 +12,7 @@ export const isValidOfficeId = (officeId: string): boolean => officeIdPattern.te
 
 export const getOffices = async (config: Config) => {
   const availableDates = getAvailableDates(config);
-  const officeBookings = await getOfficeBookings(
+  const officeBookings = await getOfficesBookings(
     config,
     availableDates,
     config.officeQuotas.map((office) => office.name)

--- a/server/getOffices.ts
+++ b/server/getOffices.ts
@@ -1,4 +1,4 @@
-import { getOfficesBookings, getOfficeBookings } from './db/officeBookings';
+import { getOfficeBookings } from './db/officeBookings';
 import { getAvailableDates } from './availableDates';
 import { Config } from './app-config';
 import { NotFound } from './errors';
@@ -35,32 +35,5 @@ export const getOffice = async (config: Config, officeId: string) => {
       };
     }),
   };
-  return combined;
-};
-
-export const getOffices = async (config: Config) => {
-  const availableDates = getAvailableDates(config);
-  const officeBookings = await getOfficesBookings(
-    config,
-    availableDates,
-    config.officeQuotas.map((office) => office.name)
-  );
-  const indexedBookings = new Map(
-    officeBookings.map((officeBooking) => [officeBooking.name + officeBooking.date, officeBooking])
-  );
-  const combined = config.officeQuotas.map((office) => ({
-    id: office.id,
-    name: office.name,
-    quota: office.quota,
-    parkingQuota: office.parkingQuota,
-    slots: availableDates.map((date) => {
-      const booking = indexedBookings.get(office.name + date);
-      return {
-        date,
-        booked: booking?.bookingCount ?? 0,
-        bookedParking: booking?.parkingCount ?? 0,
-      };
-    }),
-  }));
   return combined;
 };

--- a/server/scripts/smoketest.ts
+++ b/server/scripts/smoketest.ts
@@ -10,6 +10,7 @@ const args = yargs.options({
 
 const authRoutes = [
   ['GET', `/api/offices`],
+  ['GET', `/api/offices/an-office`],
   ['GET', `/api/users`],
   ['GET', `/api/users/${args.user}`],
   ['PUT', `/api/users/${args.user}`],

--- a/server/tests/admin-users.test.ts
+++ b/server/tests/admin-users.test.ts
@@ -49,7 +49,7 @@ test('can query custom quota users', async () => {
 test('can create and delete bookings for other people', async () => {
   const createBookingBody = {
     user: otherUser,
-    office: officeQuotas[0].name,
+    office: { id: officeQuotas[0].id },
     date: format(new Date(), 'yyyy-MM-dd'),
     parking: false,
   };

--- a/server/tests/admin-users.test.ts
+++ b/server/tests/admin-users.test.ts
@@ -34,7 +34,7 @@ test('can query admin users', async () => {
           canManageAllBookings: true,
           canViewAdminPanel: true,
           canViewUsers: true,
-          officesCanManageBookingsFor: ['Office A', 'Office B'],
+          officesCanManageBookingsFor: officeQuotas,
         },
       },
     ],
@@ -117,7 +117,7 @@ test('can set user role', async () => {
   expect(getInitialUserResponse.body).toMatchObject({ role: { name: 'Default' } });
 
   const putUserBody = {
-    role: { name: 'Office Admin', offices: [officeQuotas[0].name] },
+    role: { name: 'Office Admin', offices: [{ id: officeQuotas[0].id }] },
   };
   const putResponse = await app
     .put(`/api/users/${otherUser}`)

--- a/server/tests/admin-users.test.ts
+++ b/server/tests/admin-users.test.ts
@@ -124,6 +124,7 @@ test('can set user role', async () => {
     .send(putUserBody)
     .set('bearer', adminUserEmail);
   expect(putResponse.status).toBe(200);
+  expect(putResponse.body).toMatchObject(putUserBody);
 
   const queryResponse = await app.get(`/api/users?role=Office Admin`).set('bearer', adminUserEmail);
   expect(queryResponse.body.users).toContainEqual(putResponse.body);

--- a/server/tests/all-users.test.ts
+++ b/server/tests/all-users.test.ts
@@ -32,7 +32,13 @@ describe.each(Object.keys(userTypes))('All-user permitted actions', (userType) =
       const response = await app.get(`/api/offices`).set('bearer', email);
       expect(response.ok).toBe(true);
       expect(response.body).toHaveLength(officeQuotas.length);
-      expect(Object.keys(response.body[0])).toEqual(['name', 'quota', 'parkingQuota', 'slots']);
+      expect(Object.keys(response.body[0])).toEqual([
+        'id',
+        'name',
+        'quota',
+        'parkingQuota',
+        'slots',
+      ]);
       expect(Object.keys(response.body[0].slots[0])).toEqual(['date', 'booked', 'bookedParking']);
     });
 

--- a/server/tests/all-users.test.ts
+++ b/server/tests/all-users.test.ts
@@ -50,7 +50,7 @@ describe.each(Object.keys(userTypes))('All-user permitted actions', (userType) =
     test('can create and delete own booking', async () => {
       const createBookingBody = {
         user: email,
-        office: officeQuotas[0].name,
+        office: { id: officeQuotas[0].id },
         date: format(addDays(new Date(), 1), 'yyyy-MM-dd'),
         parking: true,
       };

--- a/server/tests/all-users.test.ts
+++ b/server/tests/all-users.test.ts
@@ -28,7 +28,7 @@ describe.each(Object.keys(userTypes))('All-user permitted actions', (userType) =
       expect(response.body?.quota).toBeGreaterThanOrEqual(0);
     });
 
-    test(`can get list of offices `, async () => {
+    test(`can get list of offices`, async () => {
       const response = await app.get(`/api/offices`).set('bearer', email);
       expect(response.ok).toBe(true);
       expect(response.body).toHaveLength(officeQuotas.length);
@@ -40,6 +40,13 @@ describe.each(Object.keys(userTypes))('All-user permitted actions', (userType) =
         'slots',
       ]);
       expect(Object.keys(response.body[0].slots[0])).toEqual(['date', 'booked', 'bookedParking']);
+    });
+
+    test(`can get single office`, async () => {
+      const response = await app.get(`/api/offices/${officeQuotas[0].id}`).set('bearer', email);
+      expect(response.ok).toBe(true);
+      expect(Object.keys(response.body)).toEqual(['id', 'name', 'quota', 'parkingQuota', 'slots']);
+      expect(Object.keys(response.body.slots[0])).toEqual(['date', 'booked', 'bookedParking']);
     });
 
     test('can get own bookings', async () => {

--- a/server/tests/booking.test.ts
+++ b/server/tests/booking.test.ts
@@ -13,11 +13,11 @@ beforeEach(resetDb);
 describe('Testing DB logic', async () => {
   test('can create booking and successfully increase booking count', async () => {
     const normalUserEmail = getNormalUser();
-    const office = config.officeQuotas[0].name;
+    const office = config.officeQuotas[0];
     const date = format(nextMonday, 'yyyy-MM-dd');
     const createBookingBody = {
       user: normalUserEmail,
-      office,
+      office: { id: office.id },
       date,
       parking: false,
     };
@@ -34,7 +34,9 @@ describe('Testing DB logic', async () => {
     expect(getCreatedBookingResponse.body).toContainEqual(createResponse.body);
 
     const getOfficeBookingsResponse = await app.get(`/api/offices`).set('bearer', normalUserEmail);
-    const officeData = getOfficeBookingsResponse.body.find((item: any) => item.name === office);
+    const officeData = getOfficeBookingsResponse.body.find(
+      (item: any) => item.name === office.name
+    );
     const slot = officeData.slots.find((item: any) => item.date === date);
     expect(slot.booked).toEqual(1);
     expect(slot.bookedParking).toEqual(0);
@@ -42,11 +44,11 @@ describe('Testing DB logic', async () => {
 
   test('can delete booking and successfully decrease booking count', async () => {
     const normalUserEmail = getNormalUser();
-    const office = config.officeQuotas[0].name;
+    const office = config.officeQuotas[0];
     const date = format(nextMonday, 'yyyy-MM-dd');
     const createBookingBody = {
       user: normalUserEmail,
-      office,
+      office: { id: office.id },
       date,
       parking: false,
     };
@@ -66,18 +68,20 @@ describe('Testing DB logic', async () => {
     expect(deleteResponse.status).toBe(204);
 
     const getOfficeBookingsResponse = await app.get(`/api/offices`).set('bearer', normalUserEmail);
-    const officeData = getOfficeBookingsResponse.body.find((item: any) => item.name === office);
+    const officeData = getOfficeBookingsResponse.body.find(
+      (item: any) => item.name === office.name
+    );
     const slot = officeData.slots.find((item: any) => item.date === date);
     expect(slot.booked).toEqual(0);
   });
 
   test('can create booking with parking and successfully increase booking count and parking count', async () => {
     const normalUserEmail = getNormalUser();
-    const office = config.officeQuotas[0].name;
+    const office = config.officeQuotas[0];
     const date = format(addDays(nextMonday, 1), 'yyyy-MM-dd');
     const createBookingBody = {
       user: normalUserEmail,
-      office,
+      office: { id: office.id },
       date,
       parking: true,
     };
@@ -94,7 +98,9 @@ describe('Testing DB logic', async () => {
     expect(getCreatedBookingResponse.body).toContainEqual(createResponse.body);
 
     const getOfficeBookingsResponse = await app.get(`/api/offices`).set('bearer', normalUserEmail);
-    const officeData = getOfficeBookingsResponse.body.find((item: any) => item.name === office);
+    const officeData = getOfficeBookingsResponse.body.find(
+      (item: any) => item.name === office.name
+    );
     const slot = officeData.slots.find((item: any) => item.date === date);
     expect(slot.booked).toEqual(1);
     expect(slot.bookedParking).toEqual(1);
@@ -102,11 +108,11 @@ describe('Testing DB logic', async () => {
 
   test('can delete booking with parking and successfully decrease booking count and parking count', async () => {
     const normalUserEmail = getNormalUser();
-    const office = config.officeQuotas[0].name;
+    const office = config.officeQuotas[0];
     const date = format(addDays(nextMonday, 1), 'yyyy-MM-dd');
     const createBookingBody = {
       user: normalUserEmail,
-      office,
+      office: { id: office.id },
       date,
       parking: true,
     };
@@ -128,7 +134,9 @@ describe('Testing DB logic', async () => {
     expect(deleteResponse.status).toBe(204);
 
     const getOfficeBookingsResponse = await app.get(`/api/offices`).set('bearer', normalUserEmail);
-    const officeData = getOfficeBookingsResponse.body.find((item: any) => item.name === office);
+    const officeData = getOfficeBookingsResponse.body.find(
+      (item: any) => item.name === office.name
+    );
     const slot = officeData.slots.find((item: any) => item.date === date);
     expect(slot.booked).toEqual(0);
     expect(slot.bookedParking).toEqual(0);
@@ -136,11 +144,10 @@ describe('Testing DB logic', async () => {
 
   test('cannot have multiple bookings on the same day', async () => {
     const normalUserEmail = getNormalUser();
-    const office = config.officeQuotas[0].name;
     const date = format(addDays(nextMonday, 1), 'yyyy-MM-dd');
     const createBookingBody = {
       user: normalUserEmail,
-      office,
+      office: { id: config.officeQuotas[0].id },
       date,
       parking: true,
     };
@@ -161,10 +168,9 @@ describe('Testing DB logic', async () => {
 
   test('cannot exceed weekly quota', async () => {
     const normalUserEmail = getNormalUser();
-    const office = config.officeQuotas[0].name;
     const createBookingBody = {
       user: normalUserEmail,
-      office,
+      office: { id: config.officeQuotas[0].id },
       parking: true,
     };
 
@@ -192,10 +198,9 @@ describe('Testing DB logic', async () => {
 
   test('booking failing due to lack of parking', async () => {
     const normalUserEmail = getNormalUser();
-    const office = config.officeQuotas[1].name;
     const createBookingBody = {
       user: normalUserEmail,
-      office,
+      office: { id: config.officeQuotas[1].id },
       parking: true,
     };
 

--- a/server/tests/booking.test.ts
+++ b/server/tests/booking.test.ts
@@ -33,10 +33,10 @@ describe('Testing DB logic', async () => {
       .set('bearer', normalUserEmail);
     expect(getCreatedBookingResponse.body).toContainEqual(createResponse.body);
 
-    const getOfficeBookingsResponse = await app.get(`/api/offices`).set('bearer', normalUserEmail);
-    const officeData = getOfficeBookingsResponse.body.find(
-      (item: any) => item.name === office.name
-    );
+    const getOfficeBookingsResponse = await app
+      .get(`/api/offices/${office.id}`)
+      .set('bearer', normalUserEmail);
+    const officeData = getOfficeBookingsResponse.body;
     const slot = officeData.slots.find((item: any) => item.date === date);
     expect(slot.booked).toEqual(1);
     expect(slot.bookedParking).toEqual(0);
@@ -67,10 +67,10 @@ describe('Testing DB logic', async () => {
       .set('bearer', normalUserEmail);
     expect(deleteResponse.status).toBe(204);
 
-    const getOfficeBookingsResponse = await app.get(`/api/offices`).set('bearer', normalUserEmail);
-    const officeData = getOfficeBookingsResponse.body.find(
-      (item: any) => item.name === office.name
-    );
+    const getOfficeBookingsResponse = await app
+      .get(`/api/offices/${office.id}`)
+      .set('bearer', normalUserEmail);
+    const officeData = getOfficeBookingsResponse.body;
     const slot = officeData.slots.find((item: any) => item.date === date);
     expect(slot.booked).toEqual(0);
   });
@@ -97,10 +97,10 @@ describe('Testing DB logic', async () => {
       .set('bearer', normalUserEmail);
     expect(getCreatedBookingResponse.body).toContainEqual(createResponse.body);
 
-    const getOfficeBookingsResponse = await app.get(`/api/offices`).set('bearer', normalUserEmail);
-    const officeData = getOfficeBookingsResponse.body.find(
-      (item: any) => item.name === office.name
-    );
+    const getOfficeBookingsResponse = await app
+      .get(`/api/offices/${office.id}`)
+      .set('bearer', normalUserEmail);
+    const officeData = getOfficeBookingsResponse.body;
     const slot = officeData.slots.find((item: any) => item.date === date);
     expect(slot.booked).toEqual(1);
     expect(slot.bookedParking).toEqual(1);
@@ -133,10 +133,10 @@ describe('Testing DB logic', async () => {
       .set('bearer', normalUserEmail);
     expect(deleteResponse.status).toBe(204);
 
-    const getOfficeBookingsResponse = await app.get(`/api/offices`).set('bearer', normalUserEmail);
-    const officeData = getOfficeBookingsResponse.body.find(
-      (item: any) => item.name === office.name
-    );
+    const getOfficeBookingsResponse = await app
+      .get(`/api/offices/${office.id}`)
+      .set('bearer', normalUserEmail);
+    const officeData = getOfficeBookingsResponse.body;
     const slot = officeData.slots.find((item: any) => item.date === date);
     expect(slot.booked).toEqual(0);
     expect(slot.bookedParking).toEqual(0);

--- a/server/tests/non-admin-users.test.ts
+++ b/server/tests/non-admin-users.test.ts
@@ -48,7 +48,7 @@ describe.each(Object.keys(userTypes))('Non-admin user actions', (userType) => {
         .post('/api/bookings')
         .send({
           user: otherUser,
-          office: officeQuotas[0].name,
+          office: { id: officeQuotas[0].id },
           date: format(new Date(), 'yyyy-MM-dd'),
           parking: false,
         })

--- a/server/tests/office-admin-users.test.ts
+++ b/server/tests/office-admin-users.test.ts
@@ -9,13 +9,13 @@ const otherUser = getNormalUser();
 
 const officeAdminEmail = 'office-a.admin@office-booker.test';
 
-const officeName = officeQuotas[0].name;
-const officeNameEncoded = encodeURIComponent(officeName);
+const office = officeQuotas[0];
+const officeNameEncoded = encodeURIComponent(office.name);
 beforeEach(async () => {
   await resetDb();
   await setUser(config, {
     email: officeAdminEmail,
-    adminOffices: [officeName],
+    adminOffices: [office.name],
     quota: 1,
   });
 });
@@ -27,13 +27,13 @@ test(`can get self`, async () => {
     email: officeAdminEmail,
     quota: 1,
     admin: false,
-    role: { name: 'Office Admin', offices: [officeName] },
+    role: { name: 'Office Admin', offices: [office] },
     permissions: {
       canEditUsers: false,
       canManageAllBookings: false,
       canViewAdminPanel: true,
       canViewUsers: true,
-      officesCanManageBookingsFor: [officeName],
+      officesCanManageBookingsFor: [office],
     },
   });
 });
@@ -79,7 +79,7 @@ test(`can't see all bookings`, async () => {
 test('can create and delete bookings for other people for their office', async () => {
   const createBookingBody = {
     user: otherUser,
-    office: officeName,
+    office: office.name,
     date: format(new Date(), 'yyyy-MM-dd'),
     parking: false,
   };

--- a/server/tests/office-admin-users.test.ts
+++ b/server/tests/office-admin-users.test.ts
@@ -10,7 +10,6 @@ const otherUser = getNormalUser();
 const officeAdminEmail = 'office-a.admin@office-booker.test';
 
 const office = officeQuotas[0];
-const officeNameEncoded = encodeURIComponent(office.name);
 beforeEach(async () => {
   await resetDb();
   await setUser(config, {
@@ -66,7 +65,7 @@ test(`can't set user quotas`, async () => {
 
 test(`can see office bookings`, async () => {
   const response = await app
-    .get('/api/bookings?office=' + officeNameEncoded)
+    .get('/api/bookings?office=' + office.id)
     .set('bearer', officeAdminEmail);
   expect(response.ok).toBe(true);
 });
@@ -101,7 +100,7 @@ test('can create and delete bookings for other people for their office', async (
   expect(createResponse.body).toMatchObject(createBookingBody);
 
   const getCreatedBookingResponse = await app
-    .get(`/api/bookings?user=${otherUser}&office=${officeNameEncoded}`)
+    .get(`/api/bookings?user=${otherUser}&office=${office.id}`)
     .set('bearer', officeAdminEmail);
   expect(getCreatedBookingResponse.body).toContainEqual(createResponse.body);
 

--- a/server/tests/office-admin-users.test.ts
+++ b/server/tests/office-admin-users.test.ts
@@ -79,7 +79,7 @@ test(`can't see all bookings`, async () => {
 test('can create and delete bookings for other people for their office', async () => {
   const createBookingBody = {
     user: otherUser,
-    office: office.name,
+    office: { id: office.id },
     date: format(new Date(), 'yyyy-MM-dd'),
     parking: false,
   };
@@ -119,7 +119,7 @@ test('can create and delete bookings for other people for their office', async (
 test(`can't create and delete bookings for other people for other offices`, async () => {
   const createBookingBody = {
     user: otherUser,
-    office: officeQuotas[1].name,
+    office: { id: officeQuotas[1].id },
     date: format(new Date(), 'yyyy-MM-dd'),
     parking: false,
   };

--- a/server/users/model.ts
+++ b/server/users/model.ts
@@ -102,7 +102,7 @@ export const makeUser = (config: Config, dbUser: DbUser): User => {
 };
 
 /** Source: https://emailregex.com/ */
-const emailRegex = /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/g.compile();
+const emailRegex = /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
 export const isValidEmail = (email: string): boolean => emailRegex.test(email);
 
 export const getUser = async (config: Config, userEmail: string): Promise<User> => {

--- a/server/users/putUser.ts
+++ b/server/users/putUser.ts
@@ -1,6 +1,7 @@
 import { Config } from '../app-config';
 import { getUserDb, setUser } from '../db/users';
 import { User, PutUserBody, getUser } from './model';
+import { Arrays } from 'collection-fns';
 
 export const putUser = async (
   config: Config,
@@ -17,7 +18,10 @@ export const putUser = async (
       return user.adminOffices;
     }
     if (putBody.role.name === 'Office Admin') {
-      return putBody.role.offices;
+      return Arrays.choose(putBody.role.offices, (office) => {
+        const officeQuota = config.officeQuotas.find((officeQuota) => officeQuota.id === office.id);
+        return officeQuota?.id;
+      });
     }
 
     return [];

--- a/server/users/putUser.ts
+++ b/server/users/putUser.ts
@@ -20,7 +20,7 @@ export const putUser = async (
     if (putBody.role.name === 'Office Admin') {
       return Arrays.choose(putBody.role.offices, (office) => {
         const officeQuota = config.officeQuotas.find((officeQuota) => officeQuota.id === office.id);
-        return officeQuota?.id;
+        return officeQuota?.name;
       });
     }
 


### PR DESCRIPTION
Related to #74 

This introduces the ids on all APIs and updates the client to use the office-id for all interactions.

We still need to migrate the database tables to actually store against the IDs too before we can close the issue.

This also significantly improves the performance of loading the office quotas which should reduce the cost of running the solution for large deployments.