### PR TITLE
Add read-only API emergency switch

### DIFF
--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -49,6 +49,7 @@ export type Config = {
   advanceBookingDays: number;
   dataRetentionDays: number;
   showTestBanner: boolean;
+  readonly?: boolean;
 };
 
 const parseOfficeQuotas = (OFFICE_QUOTAS: string) => {
@@ -150,5 +151,6 @@ export const parseConfigFromEnv = (env: typeof process.env): Config => {
     advanceBookingDays,
     dataRetentionDays,
     showTestBanner: env.SHOW_TEST_BANNER === 'true',
+    readonly: env.READONLY === 'true',
   };
 };

--- a/server/app.ts
+++ b/server/app.ts
@@ -87,6 +87,19 @@ export const configureApp = (config: Config) => {
 
   configureAuth(config, app);
 
+  app.use((req, res, next) => {
+    if (config.readonly) {
+      if (req.method === 'GET' || req.method === 'OPTIONS' || req.method === 'HEAD') {
+        return next();
+      } else {
+        return next(
+          new HttpError({ httpMessage: 'Service currently in read-only mode', status: 503 })
+        );
+      }
+    }
+    return next();
+  });
+
   app.get('/api/offices', async (_req, res, next) => {
     try {
       return res.json(config.officeQuotas);


### PR DESCRIPTION
- Allow quick mechanism to stop all modifications to the system while keeping the app online to show existing bookings.
- Uses existing logging mechanism so we can see what actions were denied by whom.
- Don't block self-test endpoint POST as it doesn't make any modifications.

![image](https://user-images.githubusercontent.com/331676/92253898-069c5500-eec8-11ea-99b7-e3b4e4aaaf6b.png)
