### PR TITLE
Enable users migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0] - 2020-09-14
+
+- Introduced users migration to store all active users in DynamoDB.
+- Use custom registration endpoint to ensure username are validated before signing up
+
+## [1.0.0] - 2020-06-07
+
+First open source release - open preview.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Office Booker (Open Preview)
+# Office Booker
 
 The Office Booker was created to solve the problem of coordinating the safe return to offices once COVID-19 restrictions are lifted.
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -46,6 +46,7 @@ export const configureApp = (config: Config) => {
   app.get('/api/config', (req, res, next) => {
     try {
       const clientConfig = {
+        version: '1.1.0',
         showTestBanner: config.showTestBanner,
         auth:
           config.authConfig.type === 'cognito'


### PR DESCRIPTION
- Deploy client before starting migration.
- Use env instead of param for migration env - causes the command to be too long otherwise.
- Fix marking migrations as complete (specify type and call function).
- Catch error if migration flag doesn't exist.
- Explicitly set region for parameters.
- Show version on the config API.