### PR TITLE
126 auto approved to admin users page

### DIFF
--- a/client/src/context/stores.ts
+++ b/client/src/context/stores.ts
@@ -28,7 +28,6 @@ export type Config = {
     | { type: 'test' };
   emailRegex?: string;
   advancedBookingDays: number;
-  autoApprovedEmails: string[];
   reasonToBookRequired: boolean;
 };
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -51,6 +51,11 @@ export const queryUsers = async (
   if (query.quota !== undefined) {
     url.searchParams.set('quota', query.quota);
   }
+
+  if (query.autoApproved !== undefined) {
+    url.searchParams.set('autoApproved', query.autoApproved);
+  }
+
   if (query.emailPrefix !== undefined) {
     url.searchParams.set('emailPrefix', query.emailPrefix);
   }
@@ -109,6 +114,7 @@ export const putUser = async (user: {
   email: string;
   quota?: number | null;
   role?: DefaultRole | OfficeAdminRole;
+  autoApproved?: boolean;
 }): Promise<User> => {
   const url = new URL(`users/${user.email}`, BASE_URL);
 
@@ -117,7 +123,7 @@ export const putUser = async (user: {
   const response = await fetch(url.href, {
     method: 'PUT',
     headers,
-    body: JSON.stringify({ quota: user.quota, role: user.role }),
+    body: JSON.stringify({ quota: user.quota, role: user.role, autoApproved: user.autoApproved }),
   });
 
   if (!response.ok) {

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -15,7 +15,12 @@ export type SystemAdminRole = { name: 'System Admin' };
 export type OfficeAdminRole = { name: 'Office Admin'; offices: Office[] };
 export type UserRole = DefaultRole | SystemAdminRole | OfficeAdminRole;
 
-export type UserQuery = { quota?: 'custom'; role?: UserRole['name']; emailPrefix?: string };
+export type UserQuery = {
+  quota?: 'custom';
+  role?: UserRole['name'];
+  autoApproved?: 'true';
+  emailPrefix?: string;
+};
 
 export type UserQueryResponse = { users: User[]; paginationToken?: string };
 
@@ -23,6 +28,7 @@ export type User = {
   email: string;
   quota: number;
   role: UserRole;
+  autoApproved?: boolean;
   permissions: {
     canViewAdminPanel: boolean;
     canViewUsers: boolean;

--- a/client/test/data.ts
+++ b/client/test/data.ts
@@ -7,7 +7,6 @@ export const createFakeConfig = (prototype?: Partial<Config>): Config => ({
   advancedBookingDays: 14,
   auth: { type: 'test' },
   showTestBanner: false,
-  autoApprovedEmails: ['vip.user1@domain.test', 'vip.user2@domain.test', 'vip.user3@domain.test'],
   reasonToBookRequired: false,
   ...prototype,
 });
@@ -46,6 +45,21 @@ export const createFakeUser = (prototype?: Partial<User>): User => ({
   },
   quota: 5,
   role: { name: 'Default' },
+  ...prototype,
+});
+
+export const createFakeAutoApprovedUser = (prototype?: Partial<User>): User => ({
+  email: 'mock.user@domain.test',
+  permissions: {
+    canEditUsers: false,
+    canManageAllBookings: false,
+    canViewAdminPanel: false,
+    canViewUsers: false,
+    officesCanManageBookingsFor: [],
+  },
+  quota: 5,
+  role: { name: 'Default' },
+  autoApproved: true,
   ...prototype,
 });
 

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -28,7 +28,6 @@ const caseSensitiveEmail = config.getBoolean('case-sensitive-email') ?? false;
 const dnsZone = config.require('dns-zone');
 const showTestBanner = config.getBoolean('show-test-banner') ?? false;
 export const systemAdminEmails = config.requireObject<string[]>('system-admin-emails').join(';');
-export const autoApprovedEmails = config.requireObject<string[]>('auto-approved-emails').join(';');
 export const officeQuotas = JSON.stringify(
   config.requireObject<{ name: string; quota: number }[]>('office-quotas')
 );
@@ -413,7 +412,6 @@ const getHttpEnv = (): aws.types.input.lambda.FunctionEnvironment['variables'] =
     SELFTESTKEY: selfTestKey,
     SELFTESTUSER: selfTestUser,
     SYSTEM_ADMIN_EMAILS: systemAdminEmails,
-    AUTO_APPROVED_EMAILS: autoApprovedEmails,
     EMAIL_REGEX: emailRegex,
     DEFAULT_WEEKLY_QUOTA: defaultWeeklyQuota.toString(),
     DATA_RETENTION_DAYS: logRetention.toString(),

--- a/make-env.sh
+++ b/make-env.sh
@@ -7,7 +7,6 @@ AWS_REGION=`pulumi config get aws:region`
 COGNITO_USER_POOL_ID=`pulumi stack output cognitoPoolId`
 COGNITO_CLIENT_ID=`pulumi stack output cognitoAuthClientId`
 SYSTEM_ADMIN_EMAILS=`pulumi stack output systemAdminEmails`
-AUTO_APPROVED_EMAILS=`pulumi stack output autoApprovedEmails`
 EMAIL_REGEX=`pulumi config get email-regex`
 OFFICE_QUOTAS=`pulumi stack output officeQuotas`
 DEFAULT_WEEKLY_QUOTA=`pulumi config get default-weekly-quota`

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -45,7 +45,6 @@ export type Config = {
   selfTestUser?: string;
   officeQuotas: OfficeQuota[];
   systemAdminEmails: string[];
-  autoApprovedEmails: string[];
   validEmailMatch?: RegExp;
   caseSensitiveEmail?: boolean;
   defaultWeeklyQuota: number;
@@ -87,7 +86,6 @@ export const parseConfigFromEnv = (env: typeof process.env): Config => {
     REGION,
     COGNITO_USER_POOL_ID,
     SYSTEM_ADMIN_EMAILS,
-    AUTO_APPROVED_EMAILS,
     EMAIL_REGEX,
     OFFICE_QUOTAS,
     DEFAULT_WEEKLY_QUOTA,
@@ -112,7 +110,6 @@ export const parseConfigFromEnv = (env: typeof process.env): Config => {
     REGION === undefined ||
     COGNITO_USER_POOL_ID === undefined ||
     SYSTEM_ADMIN_EMAILS === undefined ||
-    AUTO_APPROVED_EMAILS === undefined ||
     EMAIL_REGEX === undefined ||
     OFFICE_QUOTAS === undefined ||
     EMAIL_REGEX === undefined ||
@@ -132,10 +129,7 @@ export const parseConfigFromEnv = (env: typeof process.env): Config => {
   if (!systemAdminEmails.every(isValidEmail)) {
     throw new Error('Invalid email addresses in SYSTEM_ADMIN_EMAILS');
   }
-  const autoApprovedEmails = AUTO_APPROVED_EMAILS.split(';');
-  if (!autoApprovedEmails.every(isValidEmail)) {
-    throw new Error('Invalid email addresses in AUTO_APPROVED_EMAILS');
-  }
+
   const officeQuotaConfigs = parseOfficeQuotas(OFFICE_QUOTAS);
   const defaultWeeklyQuota = Number.parseInt(DEFAULT_WEEKLY_QUOTA);
   assert(defaultWeeklyQuota >= 0, `DEFAULT_WEEKLY_QUOTA must be >= 0`);
@@ -157,7 +151,6 @@ export const parseConfigFromEnv = (env: typeof process.env): Config => {
     selfTestUser: env.SELFTESTUSER,
     officeQuotas: officeQuotaConfigs,
     systemAdminEmails: systemAdminEmails,
-    autoApprovedEmails: autoApprovedEmails,
     validEmailMatch: EMAIL_REGEX ? new RegExp(EMAIL_REGEX) : undefined,
     caseSensitiveEmail: env.CASE_SENSITIVE_EMAIL?.toLowerCase() === 'true',
     defaultWeeklyQuota,

--- a/server/app.ts
+++ b/server/app.ts
@@ -60,7 +60,6 @@ export const configureApp = (config: Config) => {
             : { type: 'test' },
         emailRegex: config.validEmailMatch?.source,
         advancedBookingDays: config.advanceBookingDays,
-        autoApprovedEmails: config.autoApprovedEmails,
         reasonToBookRequired: config.reasonToBookRequired,
       };
       return res.set('Cache-Control', 'public, max-age=3600').json(clientConfig);
@@ -145,6 +144,7 @@ export const configureApp = (config: Config) => {
       const quota = req.query.quota?.toString();
       const role: string | undefined = req.query?.role?.toString();
       const filterQuota = quota?.toLocaleLowerCase() === 'custom';
+      const autoApproved = req.query?.autoApproved?.toString() === 'true';
       const emailPrefix = req.query.emailPrefix?.toString().toLowerCase();
       const paginationToken = req.query.paginationToken?.toString();
       const authUser = await getAuthUser(res);
@@ -155,6 +155,7 @@ export const configureApp = (config: Config) => {
         customQuota: filterQuota,
         roleName: role,
         emailPrefix,
+        autoApproved,
         paginationToken,
       });
       return res.json(users);

--- a/server/bookings/createBooking.ts
+++ b/server/bookings/createBooking.ts
@@ -97,13 +97,15 @@ export const createBooking = async (
     });
   }
 
-  const configureSendNotification = () => {
-    const { fromAddress, notificationToAddress, reasonToBookRequired, autoApprovedEmails } = config;
+  const configureSendNotification = async () => {
+    const { fromAddress, notificationToAddress, reasonToBookRequired } = config;
     if (!notificationToAddress) {
       return async () => {};
     }
 
-    if (autoApprovedEmails.includes(request.user)) {
+    //get the user from db
+    const dbUser = await getUser(config, request.user.toLocaleLowerCase());
+    if (dbUser.autoApproved) {
       return async () => {};
     }
 
@@ -132,7 +134,7 @@ export const createBooking = async (
     };
   };
 
-  const sendNotificationIfRequired = configureSendNotification();
+  const sendNotificationIfRequired = await configureSendNotification();
 
   // Id date as a direct string
   const id = requestedOffice.id + '_' + request.date.replace(/-/gi, '');

--- a/server/db/users.ts
+++ b/server/db/users.ts
@@ -9,6 +9,7 @@ export interface DbUser {
   email: string;
   quota?: number;
   adminOffices?: string[];
+  autoApproved?: boolean;
   created: string;
 }
 
@@ -20,6 +21,8 @@ export class UserModel implements DbUser {
   quota?: number;
   @attribute()
   adminOffices?: string[];
+  @attribute()
+  autoApproved?: boolean;
   @attribute({
     defaultProvider: () => new Date().toISOString(),
   })
@@ -125,6 +128,7 @@ export const ensureUserExists = async (
         email: user.email,
         quota: user.quota === config.defaultWeeklyQuota ? undefined : user.quota,
         adminOffices: (user.adminOffices?.length ?? 0) === 0 ? undefined : user.adminOffices,
+        autoApproved: !config.reasonToBookRequired ? false : user.autoApproved,
         created: user.created,
       }),
       {
@@ -151,6 +155,7 @@ export const setUser = async (config: Config, user: DbUser): Promise<void> => {
         email: user.email,
         quota: user.quota === config.defaultWeeklyQuota ? undefined : user.quota,
         adminOffices: (user.adminOffices?.length ?? 0) === 0 ? undefined : user.adminOffices,
+        autoApproved: !config.reasonToBookRequired ? false : user.autoApproved,
         created: user.created,
       })
     );

--- a/server/db/users.ts
+++ b/server/db/users.ts
@@ -111,6 +111,7 @@ export const getUserDb = async (config: Config, userEmail: string): Promise<DbUs
     email,
     quota: dbUser?.quota,
     adminOffices: dbUser?.adminOffices,
+    autoApproved: dbUser?.autoApproved,
     created: pickCreated(cognitoUser?.created, dbUser?.created),
   };
 };
@@ -128,7 +129,7 @@ export const ensureUserExists = async (
         email: user.email,
         quota: user.quota === config.defaultWeeklyQuota ? undefined : user.quota,
         adminOffices: (user.adminOffices?.length ?? 0) === 0 ? undefined : user.adminOffices,
-        autoApproved: !config.reasonToBookRequired ? false : user.autoApproved,
+        autoApproved: config.reasonToBookRequired ? user?.autoApproved === true : false,
         created: user.created,
       }),
       {
@@ -155,7 +156,7 @@ export const setUser = async (config: Config, user: DbUser): Promise<void> => {
         email: user.email,
         quota: user.quota === config.defaultWeeklyQuota ? undefined : user.quota,
         adminOffices: (user.adminOffices?.length ?? 0) === 0 ? undefined : user.adminOffices,
-        autoApproved: !config.reasonToBookRequired ? false : user.autoApproved,
+        autoApproved: config.reasonToBookRequired ? user?.autoApproved === true : false,
         created: user.created,
       })
     );

--- a/server/local.ts
+++ b/server/local.ts
@@ -9,7 +9,6 @@ const getLocalConfig = (): Config => {
     return parseConfigFromEnv(process.env);
   } catch (error) {
     const adminUser = 'mock.user@domain.test';
-    const autoApprovedUsers = ['vip.user1@domain.test','vip.user2@domain.test','vip.user3@domain.test'];
 
     console.log(
       `Env not configured correctly, falling back to stub setup.\nAdmin user is ${adminUser}\n` +
@@ -22,7 +21,6 @@ const getLocalConfig = (): Config => {
       officeQuotas: [{ id: 'the-office', name: 'The Office', quota: 10, parkingQuota: 10 }],
       showTestBanner: true,
       systemAdminEmails: [adminUser],
-      autoApprovedEmails: autoApprovedUsers,
       authConfig: {
         type: 'test',
         validate: (req) => {

--- a/server/tests/all-users.test.ts
+++ b/server/tests/all-users.test.ts
@@ -6,6 +6,7 @@ import { createBooking } from '../db/bookings';
 const { app, resetDb, config } = configureServer('all-users');
 const normalUserEmail = getNormalUser();
 const officeAdminEmail = 'office-a.admin@office-booker.test';
+const autoApprovedUserEmail = 'office-booker-auto-approved-test@office-booker.test';
 
 const office = officeQuotas[0];
 beforeEach(async () => {
@@ -22,6 +23,7 @@ const userTypes: { [key: string]: string } = {
   normal: normalUserEmail,
   admin: adminUserEmail,
   officeAdmin: officeAdminEmail,
+  autoApproved: autoApprovedUserEmail,
 };
 
 describe.each(Object.keys(userTypes))('All-user permitted actions', (userType) => {
@@ -35,6 +37,7 @@ describe.each(Object.keys(userTypes))('All-user permitted actions', (userType) =
         'admin',
         'quota',
         'role',
+        'autoApproved',
         'permissions',
       ]);
       expect(typeof response.body?.admin).toBe('boolean');

--- a/server/tests/booking.test.ts
+++ b/server/tests/booking.test.ts
@@ -302,35 +302,3 @@ describe('Testing DB logic', async () => {
     expect(slot.booked).toEqual(0);
   });
 });
-
-test('can create booking for auto approved user without reason provided and successfully increase booking count and no email sent', async () => {
-  config.reasonToBookRequired = true;
-  config.notificationToAddress = 'notifications@domain.test';
-  config.fromAddress = 'office@domain.test';
-  const autoApprovedUserEmail = 'office-booker-auto-approved-test@office-booker.test';
-
-  const office = config.officeQuotas[0];
-  const date = format(addDays(nextMonday, 1), 'yyyy-MM-dd');
-  const createBookingBody = {
-    user: autoApprovedUserEmail,
-    office: { id: office.id },
-    date,
-  };
-  const createResponse = await app
-    .post('/api/bookings')
-    .send(createBookingBody)
-    .set('bearer', autoApprovedUserEmail);
-  expect(createResponse.ok).toBe(true);
-
-  const getCreatedBookingResponse = await app
-    .get(`/api/bookings?user=${autoApprovedUserEmail}`)
-    .set('bearer', autoApprovedUserEmail);
-  expect(getCreatedBookingResponse.body).toContainEqual(createResponse.body);
-
-  const getOfficeBookingsResponse = await app
-    .get(`/api/offices/${office.id}`)
-    .set('bearer', autoApprovedUserEmail);
-  const officeData = getOfficeBookingsResponse.body;
-  const slot = officeData.slots.find((item: any) => item.date === date);
-  expect(slot.booked).toEqual(1);
-});

--- a/server/tests/non-admin-users.test.ts
+++ b/server/tests/non-admin-users.test.ts
@@ -22,6 +22,7 @@ describe.each(Object.keys(userTypes))('Non-admin user actions', (userType) => {
         email,
         quota: 1,
         admin: false,
+        autoApproved: false,
         role: { name: 'Default' },
         permissions: {
           canEditUsers: false,

--- a/server/tests/test-utils.ts
+++ b/server/tests/test-utils.ts
@@ -6,7 +6,6 @@ import { randomBytes } from 'crypto';
 import { UserType } from 'aws-sdk/clients/cognitoidentityserviceprovider';
 
 export const adminUserEmail = 'office-booker-admin-test@office-booker.test';
-export const autoApprovedUserEmail = 'office-booker-auto-approved-test@office-booker.test'
 
 export const getNormalUser = () => `${randomBytes(10).toString('hex')}@office-booker.test`;
 
@@ -50,7 +49,6 @@ export const getConfig = (dynamoDBTablePrefix: string, testConfig?: TestConfig):
     env: 'test',
     officeQuotas: testConfig?.officeQuotas ?? officeQuotas,
     systemAdminEmails: testConfig?.systemAdminEmails ?? [adminUserEmail],
-    autoApprovedEmails: [autoApprovedUserEmail],
     defaultWeeklyQuota: testConfig?.defaultWeeklyQuota ?? 1,
     advanceBookingDays: 14,
     dataRetentionDays: 30,

--- a/server/users/model.ts
+++ b/server/users/model.ts
@@ -9,8 +9,7 @@ export type UserProfile = {
 export type DefaultRole = { name: 'Default' };
 export type SystemAdminRole = { name: 'System Admin' };
 export type OfficeAdminRole = { name: 'Office Admin'; offices: OfficeQuota[] };
-export type AutoApprovedRole = { name: 'Auto Approved' };
-export type UserRole = DefaultRole | SystemAdminRole | OfficeAdminRole | AutoApprovedRole;
+export type UserRole = DefaultRole | SystemAdminRole | OfficeAdminRole;
 
 export type UserRoleName = UserRole['name'];
 
@@ -18,13 +17,13 @@ export const userRoleNames: UserRoleName[] = [
   'Default',
   'System Admin',
   'Office Admin',
-  'Auto Approved',
 ];
 
 export type User = UserProfile & {
   quota: number;
   admin: boolean;
   role: UserRole;
+  autoApproved: boolean;
   permissions: {
     canViewAdminPanel: boolean;
     canViewUsers: boolean;
@@ -38,7 +37,7 @@ type PutOfficeAdminRole = Pick<OfficeAdminRole, 'name'> & {
   offices: { id: string }[];
 };
 
-export type PutUserBody = { quota?: number | null; role?: DefaultRole | PutOfficeAdminRole | AutoApprovedRole};
+export type PutUserBody = { quota?: number | null; role?: DefaultRole | PutOfficeAdminRole; autoApproved?: boolean};
 
 export const isOfficeAdminRole = (arg: any): arg is PutOfficeAdminRole => {
   if (typeof arg !== 'object') return false;
@@ -52,12 +51,14 @@ export const isOfficeAdminRole = (arg: any): arg is PutOfficeAdminRole => {
 
 export const isUserRole = (arg: any): arg is UserRole =>
   typeof arg === 'object' &&
-  (arg.name === 'Default' || arg.name === 'Auto Approved' || arg.name === 'System Admin' || isOfficeAdminRole(arg));
+  (arg.name === 'Default' || arg.name === 'System Admin' || isOfficeAdminRole(arg));
 
 export const isPutUserBody = (arg: any): arg is PutUserBody =>
   typeof arg === 'object' &&
   (typeof arg.quota === 'number' || typeof arg.quota === 'undefined' || arg.quota === null) &&
-  (typeof arg.role === 'undefined' || (isUserRole(arg.role) && arg.role.name !== 'System Admin'));
+  (typeof arg.role === 'undefined' || (isUserRole(arg.role) && arg.role.name !== 'System Admin')) &&
+  (typeof arg.autoApproved === 'boolean' || typeof arg.autoApproved === 'undefined');
+
 
 const isAdmin = (config: Config, email: string): boolean =>
   config.systemAdminEmails.includes(email);
@@ -88,7 +89,6 @@ const makeOfficeAdmin = (config: Config, dbUser: DbUser): OfficeAdminRole => {
 export const makeUser = (config: Config, dbUser: DbUser): User => {
   const admin = isAdmin(config, dbUser.email);
   const isOfficeAdmin = (dbUser.adminOffices?.length ?? 0) > 0;
-  const isAutoApprovedUser = dbUser.autoApproved;
   return {
     email: dbUser.email,
     admin,
@@ -97,9 +97,8 @@ export const makeUser = (config: Config, dbUser: DbUser): User => {
       ? { name: 'System Admin' }
       : isOfficeAdmin
       ? makeOfficeAdmin(config, dbUser)
-      : isAutoApprovedUser
-      ? { name: 'Auto Approved' }
-      : { name: 'Default' },
+        : { name: 'Default' },
+    autoApproved: dbUser.autoApproved === true,
     permissions: {
       canViewAdminPanel: admin || isOfficeAdmin,
       canViewUsers: admin || isOfficeAdmin,

--- a/server/users/putUser.ts
+++ b/server/users/putUser.ts
@@ -13,7 +13,7 @@ export const putUser = async (
 
   const quota = putBody.quota === null ? config.defaultWeeklyQuota : putBody.quota || user.quota;
 
-  const validAutoApproved = config.reasonToBookRequired ? user.autoApproved : false
+  const validAutoApproved = config.reasonToBookRequired ? putBody.autoApproved === true : false;
 
   const parseOffices = () => {
     if (putBody.role === undefined) {

--- a/server/users/putUser.ts
+++ b/server/users/putUser.ts
@@ -13,6 +13,8 @@ export const putUser = async (
 
   const quota = putBody.quota === null ? config.defaultWeeklyQuota : putBody.quota || user.quota;
 
+  const validAutoApproved = config.reasonToBookRequired ? user.autoApproved : false
+
   const parseOffices = () => {
     if (putBody.role === undefined) {
       return user.adminOffices;
@@ -32,6 +34,7 @@ export const putUser = async (
     email: user.email,
     quota,
     adminOffices: validOffices,
+    autoApproved: validAutoApproved,
     created: user.created,
   };
 

--- a/server/users/queryUsers.ts
+++ b/server/users/queryUsers.ts
@@ -45,6 +45,7 @@ export type UsersQuery = {
   customQuota: boolean;
   roleName?: string;
   emailPrefix?: string;
+  autoApproved?: boolean;
   paginationToken?: string;
 };
 
@@ -54,7 +55,7 @@ export const queryUsers = async (
   config: Config,
   query: UsersQuery
 ): Promise<QueryUsersResponse> => {
-  if (!query.customQuota && query.roleName === undefined) {
+  if (!query.customQuota && query.roleName === undefined && !query.autoApproved) {
     return getCognitoUsers(config, query.paginationToken, query.emailPrefix);
   }
   const potentialUsers =
@@ -68,6 +69,11 @@ export const queryUsers = async (
       if (query.customQuota) {
         if (user.quota === config.defaultWeeklyQuota) return false;
       }
+
+      if (query.autoApproved) {
+        if (user.autoApproved !== query.autoApproved) return false;
+      }
+
       if (query.emailPrefix !== undefined) {
         if (!user.email.startsWith(query.emailPrefix)) return false;
       }

--- a/server/users/register.ts
+++ b/server/users/register.ts
@@ -18,6 +18,7 @@ export const registerUser = async (config: Config, email: string) => {
     email,
     adminOffices: [],
     quota: config.defaultWeeklyQuota,
+    autoApproved: false,
     created: new Date().toISOString(),
   });
 


### PR DESCRIPTION
full solution fix for : https://github.com/dogfood20/office-booker-infrastructure/issues/126 

admin user creation screen:
![image](https://user-images.githubusercontent.com/18725139/112022220-fbd6a400-8b29-11eb-9d95-f97527df45e6.png)

with auto-approved user search filter: 
![image](https://user-images.githubusercontent.com/18725139/112022369-26c0f800-8b2a-11eb-8f3b-8fffe83a425a.png)
![image](https://user-images.githubusercontent.com/18725139/112022432-35a7aa80-8b2a-11eb-80d5-dde0451aa566.png)

If user is auto approved then they will not see the reason front end stuff e.g. dialog box , red text warning.